### PR TITLE
docs: define versioning schemes and enforce strict validation

### DIFF
--- a/docs/code-management/application-versioning-scheme.md
+++ b/docs/code-management/application-versioning-scheme.md
@@ -1,0 +1,89 @@
+# Application Versioning Scheme
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Operating model](#operating-model)
+- [Invariants](#invariants)
+- [Version format](#version-format)
+- [Source of truth](#source-of-truth)
+- [Increment rules](#increment-rules)
+- [Promotion workflow](#promotion-workflow)
+- [Validation and failure modes](#validation-and-failure-modes)
+- [Related documents](#related-documents)
+
+## Purpose
+Ensure every deployed application artifact has a unique, human-readable version
+identifier that is stable, auditable, and compatible with release governance.
+
+## Scope
+This scheme applies to applications that run a single active instance in
+production and follow linear promotion across environments.
+
+It does not define versioning for shared libraries or multi-active deployment
+models.
+
+## Operating model
+- Each environment runs exactly one application version at a time.
+- Promotion is linear from develop to release to production.
+- Version identifiers must be sufficient to answer, "What is running now?"
+
+## Invariants
+- Every deployed artifact maps to a unique version string.
+- The rightmost component increments on every merge to the develop branch.
+- `PATCH` increments when a promotion to the release branch is opened.
+- `MAJOR` and `MINOR` changes are explicit human decisions.
+- Version numbers are never reused or mutated after deployment.
+- The scheme avoids implicit state and hidden counters.
+
+## Version format
+Use a four-part numeric version string:
+
+```
+MAJOR.MINOR.PATCH.BUILD
+```
+
+Rules:
+- Each component is a non-negative integer with no leading zeros (except `0`).
+- `BUILD` is the rightmost component and auto-increments.
+- No suffixes or build metadata are used in the version string.
+
+## Source of truth
+- The canonical version string lives in a single build or package manifest.
+- All other references must derive from that value; do not duplicate it in code.
+- Runtime reads should use package metadata rather than hard-coded strings.
+
+## Increment rules
+- `BUILD` increments by exactly 1 on every merge to the develop branch.
+- `PATCH` increments by exactly 1 when a promotion to the release branch opens
+  and resets `BUILD` to `0`.
+- `MAJOR` and `MINOR` changes reset `PATCH` and `BUILD` to `0`.
+- Version changes are part of merge pull requests; direct commits to develop
+  or release branches are forbidden.
+- If the develop branch advances before merge, rebase and reapply the next
+  `BUILD` value to avoid collisions.
+
+## Promotion workflow
+1. Create a promotion branch from develop and open a pull request to the
+   release branch.
+2. If the release branch has diverged, merge release into the promotion branch
+   and resolve conflicts there.
+3. Immediately open a separate pull request back to develop that increments
+   `PATCH` and resets `BUILD` to `0`.
+4. Merge the promotion pull request only after release validation.
+5. Merge the `PATCH` bump pull request before the next develop merge.
+6. Promote release to production with no additional version changes.
+
+## Validation and failure modes
+CI must fail when:
+- The version string does not match `MAJOR.MINOR.PATCH.BUILD`.
+- `BUILD` is not exactly one higher than the current develop value for
+  merge pull requests.
+- `PATCH` bump pull requests do not reset `BUILD` to `0`.
+- A version number is reused or regresses.
+
+Violations are fatal exceptions that block merges, releases, and deployments.
+
+## Related documents
+- Release and versioning policy: [release-versioning.md](release-versioning.md)
+- Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)

--- a/docs/code-management/library-versioning-scheme.md
+++ b/docs/code-management/library-versioning-scheme.md
@@ -1,0 +1,78 @@
+# Library Versioning Scheme
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Invariants](#invariants)
+- [Version format](#version-format)
+- [Source of truth](#source-of-truth)
+- [Increment rules](#increment-rules)
+- [Release workflow](#release-workflow)
+- [Dependency management](#dependency-management)
+- [Validation and failure modes](#validation-and-failure-modes)
+- [Related documents](#related-documents)
+
+## Purpose
+Define how supporting libraries are versioned, released, and consumed.
+
+## Scope
+This scheme applies to internal and external libraries used by applications.
+
+## Invariants
+- Every released library artifact maps to a unique version string.
+- Version numbers are never reused or mutated after release.
+- Releases are immutable and reproducible from source.
+- Compatibility expectations are explicit and tied to the version number.
+
+## Version format
+Use Semantic Versioning:
+
+```
+MAJOR.MINOR.PATCH
+```
+
+Rules:
+- Each component is a non-negative integer with no leading zeros (except `0`).
+- Stable releases do not use suffixes or build metadata.
+- Pre-release identifiers are allowed only for pre-release artifacts and must
+  never be promoted to production as-is.
+
+## Source of truth
+- The canonical version string lives in a single build or package manifest.
+- All other references must derive from that value; do not duplicate it in code.
+- Runtime reads should use package metadata rather than hard-coded strings.
+
+## Increment rules
+- `MAJOR` increments for breaking API or behavioral changes.
+- `MINOR` increments for backward-compatible features or expansions.
+- `PATCH` increments for backward-compatible bug fixes.
+- Changes that are not backward-compatible must never ship without a `MAJOR`
+  increment.
+- Pre-1.0 libraries must still follow the same rules; the `0.x` series does not
+  waive compatibility discipline.
+
+## Release workflow
+1. Assign a version at release time and tag it in source control.
+2. Build and publish an immutable artifact for that version.
+3. Ensure the released artifact matches the tagged source exactly.
+4. Produce release notes that describe compatibility impact.
+
+## Dependency management
+- Applications and libraries must consume explicit version ranges that encode
+  compatibility expectations.
+- Production builds must pin exact versions via lockfiles or equivalent
+  mechanisms to ensure reproducibility.
+- Upgrades are deliberate changes, not background drift.
+
+## Validation and failure modes
+CI must fail when:
+- The version string does not match `MAJOR.MINOR.PATCH`.
+- A version number is reused or regresses.
+- A release is attempted from untagged or dirty source.
+- A breaking change is detected without a `MAJOR` increment.
+
+Violations are fatal exceptions that block publishing and consumption.
+
+## Related documents
+- Release and versioning policy: [release-versioning.md](release-versioning.md)
+- Application versioning scheme: [application-versioning-scheme.md](application-versioning-scheme.md)

--- a/docs/code-management/overview.md
+++ b/docs/code-management/overview.md
@@ -18,5 +18,7 @@ tool-specific requirements belong in development standards.
 - Branching and deployment: [branching-and-deployment.md](branching-and-deployment.md)
 - Hotfix policy: [hotfix-policy.md](hotfix-policy.md)
 - Release and versioning: [release-versioning.md](release-versioning.md)
+- Application versioning scheme: [application-versioning-scheme.md](application-versioning-scheme.md)
+- Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)
 - Commit messages and authorship: [commit-messages-and-authorship.md](commit-messages-and-authorship.md)

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -84,6 +84,8 @@ Rollbacks are operational decisions, not code changes.
 - deploying unreleased code
 - publishing artifacts that never ran in test
 
+Violations are fatal exceptions that block merges, releases, and deployments.
+
 ---
 
 ## 8. Guiding Principle


### PR DESCRIPTION
## Summary\n- Add application and library versioning schemes\n- Align terminology to develop and enforce fatal validation language\n- Update the code-management document map\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/code-management/application-versioning-scheme.md\n- docs/code-management/library-versioning-scheme.md\n- docs/code-management/release-versioning.md\n- docs/code-management/overview.md