### PR TITLE
docs: require anchor records for dependencies

### DIFF
--- a/docs/dependencies/overview.md
+++ b/docs/dependencies/overview.md
@@ -1,0 +1,59 @@
+# Dependency Anchor Records
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Required layout](#required-layout)
+- [Record format](#record-format)
+- [Maintenance](#maintenance)
+
+## Purpose
+Provide a durable record of why a dependency is anchored below the latest
+acceptable range, including the evidence from each failed upgrade attempt.
+
+## Scope
+These records apply to any dependency that is pinned or constrained because
+newer releases fail validation or break compatibility.
+
+## Required layout
+- Create one file per anchored dependency under `docs/dependencies/`.
+- Use the dependency name for the filename (`<dependency-name>.md`) and keep
+  it stable across updates.
+- Each record must use the Markdown standards, including a Table of Contents.
+
+## Record format
+Each dependency record must include, at minimum:
+- Summary of why the dependency is anchored.
+- Current constraint and the version range in effect.
+- Failure history with evidence for each failed upgrade attempt.
+- Exit criteria for removing the anchor.
+
+Suggested template:
+
+```
+# <Dependency name>
+
+## Table of Contents
+- [Summary](#summary)
+- [Current constraint](#current-constraint)
+- [Failure history](#failure-history)
+- [Exit criteria](#exit-criteria)
+
+## Summary
+Explain the reason for the anchor and the impact.
+
+## Current constraint
+State the constraint and when it was last verified.
+
+## Failure history
+- YYYY-MM-DD: attempted <version>; test command; error excerpt; conclusion.
+- YYYY-MM-DD: attempted <version>; test command; error excerpt; conclusion.
+
+## Exit criteria
+Define what will allow the anchor to be removed.
+```
+
+## Maintenance
+- Append new failure entries for each re-test; do not overwrite prior evidence.
+- Keep the record aligned with the current constraint and latest attempted
+  version.

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -10,6 +10,7 @@
   - [Minor-level](#minor-level)
 - [In-cycle exception rules](#in-cycle-exception-rules)
 - [Handling regressions and non-latest pins](#handling-regressions-and-non-latest-pins)
+- [Anchored dependency documentation](#anchored-dependency-documentation)
 - [Locked dependency review](#locked-dependency-review)
 - [Enforcement](#enforcement)
 - [Examples (TODO)](#examples-todo)
@@ -123,6 +124,35 @@ Every pin must be accompanied by:
 - a clear exit condition and planned removal
 - a review at the next `PATCH` cycle
 
+## Anchored dependency documentation
+When a dependency is anchored below the latest acceptable range, document it in
+two places:
+
+1. `pyproject.toml` comment immediately above the dependency specification,
+   noting the latest version that failed and pointing to the dependency record.
+2. A dependency-specific record in `docs/dependencies/` that captures failure
+   evidence and preserves history across attempts.
+
+Update both records every time an upgrade is tested and fails. Do not replace or
+delete prior failure evidence.
+
+Example `pyproject.toml` comment:
+
+```
+# Anchor: 1.2.5 fails full test suite; see docs/dependencies/example-lib.md
+example-lib = ">=1.1,<2.0"
+```
+
+Dependency record requirements:
+- One file per dependency: `docs/dependencies/<dependency-name>.md`.
+- Record the failing version and a concise description of the failure.
+- Capture failure evidence (test command, error excerpt, and context).
+- Append a new entry for each failed re-test.
+- Keep the latest attempted version in the `pyproject.toml` comment.
+
+See [Dependency anchor records](../../dependencies/overview.md) for the
+required format.
+
 ## Locked dependency review
 At the start of each new `PATCH` cycle, review any pinned or tightly constrained
 dependencies and confirm each pin is still required. Remove unnecessary pins
@@ -135,6 +165,8 @@ CI must fail when:
 - `poetry.lock` is out of sync with `pyproject.toml`
 - a dependency spec uses `*`
 - a dependency is pinned without documented justification
+- a dependency anchor lacks the required `pyproject.toml` comment
+- a dependency anchor lacks a record in `docs/dependencies/`
 - dependency updates occur without the required validation run
 
 ## Examples (TODO)


### PR DESCRIPTION
## Summary\n- Require pyproject.toml anchor comments for pinned dependencies\n- Add dependency-specific anchor records under docs/dependencies\n- Define record format and maintenance rules\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/development/python/dependency-management.md\n- docs/dependencies/overview.md