### PR TITLE
docs: add python version management and docker test draft

### DIFF
--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -7,7 +7,7 @@
 - [Version specification rules](#version-specification-rules)
 - [Upgrade workflow](#upgrade-workflow)
   - [Patch-level](#patch-level)
-  - [Minor-level](#minor-level)
+  - [Minor- or major-level](#minor--or-major-level)
 - [In-cycle exception rules](#in-cycle-exception-rules)
 - [Handling regressions and non-latest pins](#handling-regressions-and-non-latest-pins)
 - [Anchored dependency documentation](#anchored-dependency-documentation)
@@ -65,8 +65,8 @@ Workflow:
 Do not change explicit version constraints in `pyproject.toml` as part of this
 cycle-opening update.
 
-### Minor-level
-When incrementing the application `MINOR` version, perform the patch-level
+### Minor- or major-level
+When incrementing the application `MINOR` or `MAJOR` version, perform the patch-level
 workflow and also attempt to move toward the latest available dependency
 releases when constraints have been tightened.
 

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -26,3 +26,4 @@ and long-term survivability across repositories.
 - Type hints: [type-hints.md](type-hints.md)
 - Testing and coverage: [testing-and-coverage.md](testing-and-coverage.md)
 - Dependency management: [dependency-management.md](dependency-management.md)
+- Python version management: [version-management.md](version-management.md)

--- a/docs/development/python/version-management.md
+++ b/docs/development/python/version-management.md
@@ -1,0 +1,94 @@
+# Python Version Management
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Core principles](#core-principles)
+- [Sources of truth](#sources-of-truth)
+- [Upgrade workflow](#upgrade-workflow)
+  - [Patch-level](#patch-level)
+  - [Minor- or major-level](#minor--or-major-level)
+- [Host decoupling and parity](#host-decoupling-and-parity)
+  - [Parity requirements](#parity-requirements)
+  - [Decoupling strategies](#decoupling-strategies)
+- [Enforcement](#enforcement)
+- [Examples (TODO)](#examples-todo)
+- [Related documents](#related-documents)
+
+## Purpose
+Define a repeatable Python version strategy that keeps runtime behavior stable
+within a development cycle while enabling controlled upgrades.
+
+## Scope
+These rules apply to the Python runtime version used in development, CI, and
+production deployments.
+
+## Core principles
+- Use a fixed Python patch version (`x.y.z`) for an entire development cycle.
+- Align development, CI, and production runtimes to the same version.
+- Evaluate Python patch upgrades at the same time as dependency upgrades.
+- Treat the Python runtime as a dependency with higher upgrade cost and risk.
+- Document any non-latest Python pin using the anchored dependency process.
+
+## Sources of truth
+- The canonical Python version is declared once in repository configuration.
+- All other references (CI config, container image tags, tooling configs) must
+  derive from the canonical value.
+
+## Upgrade workflow
+
+### Patch-level
+During the patch-cycle dependency update:
+1. Check for a newer Python patch release in the current minor series.
+2. If available, update the runtime to the new patch version.
+3. Run the full validation and test suite.
+4. If validation passes, fix the runtime to the new patch for the remainder of
+   the cycle.
+
+If the patch upgrade fails, determine root cause before pinning. If the failure
+is attributable to the runtime, anchor to the prior patch and document the
+failure evidence.
+
+### Minor- or major-level
+When incrementing the application `MINOR` or `MAJOR` version:
+1. Perform the patch-level workflow.
+2. Evaluate whether upgrading the Python minor or major version is required or
+   beneficial for the next cycle.
+3. If a runtime upgrade is attempted, test each candidate version individually
+   before combining with other changes.
+
+## Host decoupling and parity
+
+### Parity requirements
+- Prefer running development and test workflows in an environment that matches
+  the deployment operating system and runtime.
+- Avoid relying on the host OS Python for anything beyond ad-hoc commands.
+- Ensure CI validates the same runtime version used for development and
+  production.
+
+### Decoupling strategies
+Evaluate one or more of the following approaches:
+- Containerized development environments that mirror production runtime
+  versions and base operating system.
+- Standardized dev shells or wrapper scripts that run tests and tooling inside
+  the controlled runtime.
+- Remote or hosted development environments running the deployment OS.
+- Toolchain managers that install and isolate Python without modifying the
+  system runtime.
+
+## Enforcement
+Violations are fatal exceptions that block merges, releases, and deployments.
+
+CI must fail when:
+- The Python version drifts across development, CI, and production.
+- The runtime version is modified mid-cycle without the upgrade workflow.
+- A non-latest runtime pin lacks anchored dependency documentation.
+
+## Examples (TODO)
+- Patch upgrade with a runtime regression and anchor record.
+- Minor or major runtime upgrade checklist.
+- Containerized development workflow that matches production.
+
+## Related documents
+- Python dependency management: [dependency-management.md](dependency-management.md)
+- Dependency anchor records: [dependency anchor records](../../dependencies/overview.md)

--- a/drafts/dockerized-testing.md
+++ b/drafts/dockerized-testing.md
@@ -1,0 +1,54 @@
+# Dockerized Testing (Draft)
+
+## Table of Contents
+- [Status](#status)
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Decisions](#decisions)
+- [Workflow outline](#workflow-outline)
+- [Image strategy](#image-strategy)
+- [Determinism and parity](#determinism-and-parity)
+- [Open items](#open-items)
+
+## Status
+Draft for validation in a working repository. This document will be replaced by
+final guidance once the approach is proven.
+
+## Purpose
+Define a Docker-first testing workflow that provides deterministic results
+across macOS, Windows, and Linux while aligning local and CI execution.
+
+## Scope
+Applies to repositories that run unit tests in a Linux container with a pinned
+Python runtime and managed dependencies.
+
+## Decisions
+- Unit tests run only inside Docker containers; host virtual environments are
+  unsupported for test execution.
+- The test image is repository-specific.
+- The Python runtime is pinned to an explicit patch version for the duration of
+  a development cycle.
+
+## Workflow outline
+- Build or refresh the repository test image when the lockfile or runtime
+  version changes.
+- Run unit tests in a container with the repository mounted as a working
+  directory.
+- Use persistent caches for dependency installs to keep local runs fast.
+- Keep the host Python install optional; it should not be required for tests.
+
+## Image strategy
+- Base the image on the pinned Python `x.y.z` runtime.
+- Install dependencies from the lockfile and avoid ad hoc installs.
+- Ensure the image can be rebuilt deterministically from repository state.
+
+## Determinism and parity
+- The same containerized workflow must be usable locally and in CI.
+- Test execution must not depend on host OS Python behavior.
+- Prefer Linux-based containers to match deployment environments.
+
+## Open items
+- Define how integration-test services (databases, caches, queues) will be
+  orchestrated and versioned.
+- Decide whether additional tooling (linters, formatters, type checkers) runs
+  inside the same test image or a separate tooling image.


### PR DESCRIPTION
## Summary\n- Add Python runtime version management standards\n- Update dependency upgrade header to cover minor/major cycles\n- Draft docker-first testing approach for validation\n- Add the new Python doc to the overview map\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/development/python/version-management.md\n- docs/development/python/dependency-management.md\n- docs/development/python/overview.md\n- drafts/dockerized-testing.md