### PR TITLE
docs: relax dependency defaults and add promotion branches

### DIFF
--- a/docs/code-management/branching-and-deployment.md
+++ b/docs/code-management/branching-and-deployment.md
@@ -12,6 +12,7 @@
   - [feature/*](#feature)
   - [bugfix/*](#bugfix)
   - [hotfix/*](#hotfix)
+  - [promotion/*](#promotion)
 - [6. Promotion Flow](#6-promotion-flow)
 - [7. Forbidden Operations](#7-forbidden-operations)
 - [8. Guiding Principle](#8-guiding-principle)
@@ -98,6 +99,7 @@ Only the following branch prefixes are allowed:
 - feature/*
 - bugfix/*
 - hotfix/*
+- promotion/*
 
 No other prefixes are permitted. When in doubt, use feature/*.
 
@@ -141,6 +143,20 @@ Rules:
 Creation of a hotfix branch is an explicit admission of upstream process
 failure.
 
+### promotion/*
+Use for:
+- controlled promotion between eternal branches
+- release qualification or production promotion
+
+Rules:
+- branched from the source eternal branch
+- merged only into the target eternal branch
+- deleted immediately after merge
+
+Naming:
+- `promotion/release-<version>-<yyyymmddhhmmss>` for develop to release
+- `promotion/main-<version>-<yyyymmddhhmmss>` for release to main
+
 ---
 
 ## 6. Promotion Flow
@@ -162,7 +178,7 @@ The following are explicitly disallowed:
 - cherry-picking between eternal branches
 - deploying to production without passing through release
 - long-lived non-eternal branches
-- using branch prefixes other than feature/*, bugfix/*, or hotfix/*
+- using branch prefixes other than feature/*, bugfix/*, hotfix/*, or promotion/*
 
 ---
 

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -31,20 +31,20 @@ These rules apply to Python library dependencies managed with `pyproject.toml`,
   it.
 
 ## Version specification rules
-- Use the least restrictive spec that still anchors to the current major
-  version of each dependency.
-- Do not use `*` as a default constraint.
+- Default dependency specs in `pyproject.toml` use `*`.
+- Do not anchor to a major or minor series by default (including pre-1.0
+  dependencies).
+- Use constrained specs only when necessary and document them using the
+  anchored dependency workflow.
 - Avoid patch-level pinning in `pyproject.toml` unless an explicit exception
   is approved.
-- For pre-1.0 dependencies, treat minor versions as breaking and constrain to
-  the current minor series.
 - Major version upgrades are explicit, deliberate decisions and require their
   own review procedure (to be defined).
 
-Example pattern for major anchoring (syntax may vary by tooling):
+Example default specification:
 
 ```
->=2.4,<3.0
+example-lib = "*"
 ```
 
 ## Upgrade workflow
@@ -84,8 +84,8 @@ Workflow:
 6. If multiple major upgrades are viable, run the full validation and test
    suite with all major upgrades combined.
 
-The expected steady state is to remain anchored to the latest major version of
-each dependency. If no newer major release exists, there is nothing to test.
+The expected steady state is unconstrained (`*`) unless a documented exception
+requires anchoring. If no newer major release exists, there is nothing to test.
 
 If a dependency upgrade fails, determine root cause before deciding to pin or
 defer. A regression in the dependency is a valid reason to stay on the prior
@@ -154,23 +154,22 @@ See [Dependency anchor records](../../dependencies/overview.md) for the
 required format.
 
 ## Locked dependency review
-At the start of each new `PATCH` cycle, review any pinned or tightly constrained
-dependencies and confirm each pin is still required. Remove unnecessary pins
-before completing the cycle-opening update.
+At the start of each upgrade cycle (`PATCH`, `MINOR`, or `MAJOR`), review any
+pinned or tightly constrained dependencies and confirm each pin is still
+required. Remove unnecessary pins before completing the cycle-opening update.
 
 ## Enforcement
 Violations are fatal exceptions that block merges, releases, and deployments.
 
 CI must fail when:
 - `poetry.lock` is out of sync with `pyproject.toml`
-- a dependency spec uses `*`
-- a dependency is pinned without documented justification
+- a dependency spec is constrained without documented justification
 - a dependency anchor lacks the required `pyproject.toml` comment
 - a dependency anchor lacks a record in `docs/dependencies/`
 - dependency updates occur without the required validation run
 
 ## Examples (TODO)
-- Major-anchored version specifications.
+- Default `*` specifications and constrained exceptions.
 - Patch-cycle update checklist in practice.
 - Justified pinning due to upstream regression.
 - Dependency addition for new functionality.


### PR DESCRIPTION
## Summary\n- Default Python dependency specs to '*' and drop major/minor anchoring\n- Update constraint enforcement language and examples\n- Allow promotion/* branch prefixes with naming rules\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/development/python/dependency-management.md\n- docs/code-management/branching-and-deployment.md