### PR TITLE
docs: require standards reference per repo

### DIFF
--- a/docs/code-management/commit-messages-and-authorship.md
+++ b/docs/code-management/commit-messages-and-authorship.md
@@ -7,7 +7,7 @@
 - [Commit Authorship](#commit-authorship)
 - [AI Co-Authorship](#ai-co-authorship)
 - [Adding a New AI Service Account](#adding-a-new-ai-service-account)
-- [Repository-Specific AI Identities](#repository-specific-ai-identities)
+- [Project-specific AI identities](#project-specific-ai-identities)
 
 ## Commit Message Format
 Follow Conventional Commits:
@@ -61,12 +61,10 @@ Setup steps:
 3. Enable 2FA and keep the email address private.
 4. Copy the account's GitHub noreply email from Settings -> Emails.
 
-Then update the repository-specific AI co-author list below.
+Then update the repository-specific AI co-author list in
+`docs/standards-and-conventions.md`.
 
-## Repository-Specific AI Identities
-Maintain the approved AI co-author identities here. Use these exact identities
-when adding co-author trailers.
-
-```
-Co-Authored-By: ai-tool <id+ai-tool@users.noreply.github.com>
-```
+## Project-specific AI identities
+Maintain approved AI co-author identities in
+`docs/standards-and-conventions.md` for each repository. Use only the identities
+listed there when adding co-author trailers.

--- a/docs/repository/repository-structure.md
+++ b/docs/repository/repository-structure.md
@@ -45,6 +45,10 @@ Use `docs/decisions/` for ADRs. Naming and structure:
 - Keep the decision record immutable once accepted; revisions require a new
   ADR that references the original
 
+Each repository must include `docs/standards-and-conventions.md` that:
+- links to the canonical standards in this repository
+- documents project-specific overlays and deviations
+
 ## Examples
 ```
 repo/

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,0 +1,59 @@
+# Standards and Conventions Reference
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Requirement](#requirement)
+- [Canonical references](#canonical-references)
+- [Project-specific overlay](#project-specific-overlay)
+- [Template](#template)
+- [Maintenance](#maintenance)
+
+## Purpose
+Provide a required, repository-local entry point that references the canonical
+standards and documents project-specific details that do not belong upstream.
+
+## Requirement
+Every repository must include `docs/standards-and-conventions.md`.
+
+This file must:
+- reference the canonical standards in this repository using GitHub URLs
+- document project-specific information and deviations
+- avoid duplicating canonical standards verbatim
+
+## Canonical references
+Include links to the canonical documents that apply to the repository. Use
+GitHub URLs pointing to this repository.
+
+## Project-specific overlay
+Record project-specific details here, such as:
+- approved AI co-author identities for commit trailers
+- local terminology or naming conventions
+- approved deviations from canonical standards
+
+Project-specific content must be explicit and scoped. Do not restate canonical
+rules unless a deviation exists.
+
+## Template
+```
+# <Repository> Standards and Conventions
+
+This repository follows the canonical standards at:
+https://github.com/<org>/<standards-repo>
+
+## Table of Contents
+- [Canonical references](#canonical-references)
+- [Project-specific overlay](#project-specific-overlay)
+
+## Canonical references
+- <link to relevant canonical docs>
+
+## Project-specific overlay
+- AI co-authors:
+  - Co-Authored-By: ai-tool <id+ai-tool@users.noreply.github.com>
+- Local deviations:
+  - <explicit deviation, if any>
+```
+
+## Maintenance
+Keep this file short and current. Update it whenever a project-specific rule
+changes or a deviation is introduced or removed.


### PR DESCRIPTION
## Summary\n- Add required docs/standards-and-conventions.md with canonical references and project overlays\n- Move AI co-author identity storage to the project overlay doc\n- Require the file in repository structure guidance\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/standards-and-conventions.md\n- docs/code-management/commit-messages-and-authorship.md\n- docs/repository/repository-structure.md