### PR TITLE
docs: require promotion branches for release/main

### DIFF
--- a/docs/code-management/branching-and-deployment.md
+++ b/docs/code-management/branching-and-deployment.md
@@ -81,8 +81,8 @@ develop, release, or main are forbidden.
 
 - Changes to develop: create a feature/* or bugfix/* branch, then open a PR to
   develop.
-- Changes to release: create a PR from develop to release.
-- Changes to main: create a PR from release to main.
+- Changes to release: create a PR from a promotion branch to release.
+- Changes to main: create a PR from a promotion branch to main.
 - Exception: hotfix/* branches follow special forward-merge rules (see
   docs/code-management/hotfix-policy.md).
 
@@ -152,6 +152,7 @@ Rules:
 - branched from the source eternal branch
 - merged only into the target eternal branch
 - deleted immediately after merge
+ - required for normal promotions to release and main
 
 Naming:
 - `promotion/release-<version>-<yyyymmddhhmmss>` for develop to release

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -38,14 +38,13 @@ Releases are not mutable.
 ---
 
 ## 3. Versioning
-- Semantic Versioning (MAJOR.MINOR.PATCH) is used.
+- Use the applicable versioning scheme for the artifact type.
 - Version numbers are assigned at release time.
 - Version bumps are explicit and reviewed.
 
 Guideline:
-- MAJOR: breaking changes
-- MINOR: backward-compatible features
-- PATCH: bug fixes
+- Libraries: Semantic Versioning (`MAJOR.MINOR.PATCH`).
+- Applications: use the Application Versioning Scheme (`MAJOR.MINOR.PATCH.BUILD`).
 
 ---
 

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -38,8 +38,6 @@ These rules apply to Python library dependencies managed with `pyproject.toml`,
   anchored dependency workflow.
 - Avoid patch-level pinning in `pyproject.toml` unless an explicit exception
   is approved.
-- Major version upgrades are explicit, deliberate decisions and require their
-  own review procedure (to be defined).
 
 Example default specification:
 


### PR DESCRIPTION
## Summary\n- Require promotion branches for normal PRs into release and main\n- Align release versioning rules by artifact type\n- Remove the major-upgrade special case from dependency specs\n\n## Testing\nDocs-only: tests skipped\n\n## Files changed\n- docs/code-management/branching-and-deployment.md\n- docs/code-management/release-versioning.md\n- docs/development/python/dependency-management.md