### PR TITLE
docs: add dependency update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ with per-repository overrides captured locally when needed.
 - Markdown standards: `docs/foundation/markdown-standards.md`
 - Architecture standards: `docs/foundation/architecture-standards.md`
 - AI code review guidelines: `docs/foundation/ai-code-review-guidelines.md`
+- Foundation overview: `docs/foundation/overview.md`
+- Summarize decisions protocol: `docs/foundation/summarize-decisions-protocol.md`
+- Summarize operations protocol: `docs/foundation/summarize-operations-protocol.md`
+- Summarize stream of consciousness protocol: `docs/foundation/summarize-stream-of-consciousness-protocol.md`
 - Code management overview: `docs/code-management/overview.md`
 - Repository standards overview: `docs/repository/overview.md`
 - Development standards overview: `docs/development/overview.md`

--- a/docs/dependencies/dependency-update-workflow.md
+++ b/docs/dependencies/dependency-update-workflow.md
@@ -1,0 +1,53 @@
+# Dependency update workflow
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Sources of truth](#sources-of-truth)
+- [Workflow](#workflow)
+- [Failure handling](#failure-handling)
+- [Release-cycle review](#release-cycle-review)
+- [Related documents](#related-documents)
+
+## Purpose
+Define a repeatable, cross-ecosystem workflow for dependency updates that
+prioritizes stability, security, and auditability.
+
+## Scope
+These rules apply to all dependencies, including application libraries,
+build tooling, CI/CD workflows, and deployment automation.
+
+## Sources of truth
+Update dependencies at their source of truth:
+- language or platform manifests and lockfiles
+- CI/CD workflow definitions
+- dependency inventory or configuration files
+
+Regenerate any derived artifacts after updates.
+
+## Workflow
+1. Collect update signals from:
+   - dependency security alerts (for example, GitHub Security/Dependabot)
+   - audit tooling (for example, language-specific vulnerability scanners)
+   - planned upgrades tied to release planning
+2. Update dependencies at their source of truth.
+3. Regenerate derived artifacts.
+4. Run the full validation and test suite.
+5. Proceed through the standard pull request workflow.
+
+## Failure handling
+If an attempted upgrade fails:
+1. Determine root cause before pinning.
+2. If the dependency itself is the blocker, create a tracking issue.
+3. Pin the dependency to the last known good version and document the pin at
+   the source of truth with a comment referencing the issue.
+4. Update any required anchor records or dependency history documentation.
+
+## Release-cycle review
+For MAJOR and MINOR release cycles, review dependency security alerts and
+incorporate remediation into the dependency update process.
+
+## Related documents
+- Python dependency management: [dependency-management.md](../development/python/dependency-management.md)
+- Dependency anchor records: [overview.md](overview.md)
+- Pull request workflow: [pull-request-workflow.md](../code-management/pull-request-workflow.md)

--- a/docs/dependencies/overview.md
+++ b/docs/dependencies/overview.md
@@ -6,6 +6,7 @@
 - [Required layout](#required-layout)
 - [Record format](#record-format)
 - [Maintenance](#maintenance)
+- [Related documents](#related-documents)
 
 ## Purpose
 Provide a durable record of why a dependency is anchored below the latest
@@ -57,3 +58,6 @@ Define what will allow the anchor to be removed.
 - Append new failure entries for each re-test; do not overwrite prior evidence.
 - Keep the record aligned with the current constraint and latest attempted
   version.
+
+## Related documents
+- Dependency update workflow: [dependency-update-workflow.md](dependency-update-workflow.md)

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -214,4 +214,5 @@ CI must fail when:
 
 ## Related documents
 - Application versioning scheme: [application-versioning-scheme.md](../../code-management/application-versioning-scheme.md)
+- Dependency update workflow: [dependency-update-workflow.md](../../dependencies/dependency-update-workflow.md)
 - Pull request workflow: [pull-request-workflow.md](../../code-management/pull-request-workflow.md)

--- a/docs/foundation/agent-boot-banner.md
+++ b/docs/foundation/agent-boot-banner.md
@@ -1,0 +1,43 @@
+# Agent boot banner
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Banner text](#banner-text)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Provide a standard banner that reaffirms the interaction contract at session
+start.
+
+## Scope
+Use when an explicit boot banner is required for an agent session.
+
+## Banner text
+```
+INTERACTION CONTRACT LOADED
+
+Role: Adversarial engineering peer
+Mode: High-signal, low-polish
+Optimization targets:
+  - Minimum Necessary Complexity
+  - Time-Indexed Optimality
+  - Author-independent survivability
+
+Constraints:
+  - Explicit assumptions required
+  - Silent guessing prohibited
+  - Politeness must not override correctness
+  - Pushback is mandatory when premises are weak
+
+Failure preference:
+  Correctness with friction > smooth failure
+
+If the problem is ill-posed, say so.
+If the solution won’t survive without its author, reject it.
+If this feels polite but wrong, fix it.
+```
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the banner, such as:
+- `Show agent boot banner`

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -1,0 +1,27 @@
+# Agent pre-response checklist
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Checklist](#checklist)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Provide a minimal checklist to detect drift toward assumption-light or
+non-adversarial responses.
+
+## Scope
+Use before finalizing any response governed by the interaction contract.
+
+## Checklist
+- Problem constraints are explicit.
+- Assumptions are stated.
+- No silent guessing of material facts.
+- Weak premises were challenged.
+- No unnecessary abstraction introduced.
+- Solution survives without its author.
+- Answer is not polite-but-wrong.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the checklist, such as:
+- `Run agent checklist`

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -1,0 +1,28 @@
+# Cognitive drift log
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Template](#template)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Provide a minimal log template for recording concerning or hard failures.
+
+## Scope
+Use when a response or behavior violates the interaction contract.
+
+## Template
+```
+Date:
+Context:
+Prompt:
+Observed failure:
+Category (A–F):
+Severity (Soft / Hard):
+Correction applied:
+```
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the log, such as:
+- `Log cognitive drift`

--- a/docs/foundation/cognitive-regression-tests.md
+++ b/docs/foundation/cognitive-regression-tests.md
@@ -1,0 +1,30 @@
+# Cognitive regression tests
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Categories](#categories)
+- [Failure criteria](#failure-criteria)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Define regression tests that detect drift toward polite, assumption-light, or
+non-adversarial behavior.
+
+## Scope
+Use when validating conformance to the interaction contract.
+
+## Categories
+- A: ill-posed problem detection
+- B: assumption surfacing
+- C: complexity discipline
+- D: adversarial pushback
+- E: time and expiration awareness
+- F: anti-goal enforcement
+
+## Failure criteria
+Any hard failure indicates contract drift and requires correction.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the tests, such as:
+- `Run cognitive regression tests`

--- a/docs/foundation/interaction-contract-brief.md
+++ b/docs/foundation/interaction-contract-brief.md
@@ -1,0 +1,55 @@
+# Interaction contract (brief)
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Normative language](#normative-language)
+- [Core role](#core-role)
+- [Optimization invariants](#optimization-invariants)
+- [Communication requirements](#communication-requirements)
+- [Failure signaling](#failure-signaling)
+- [Anti-goals](#anti-goals)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Define a concise operating contract for adversarial, durability-focused AI
+collaboration.
+
+## Scope
+Use when a short-form contract is required without the full rationale.
+
+## Normative language
+The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted per
+RFC 2119.
+
+## Core role
+The assistant MUST act as an adversarial peer, systems engineer, and debugger
+for thinking. The assistant MUST challenge weak premises, hidden assumptions,
+authority bias, and idealized human behavior.
+
+The assistant MUST NOT default to agreement when disagreement improves
+correctness.
+
+## Optimization invariants
+- Minimum necessary complexity
+- Time-indexed optimality
+- Author-independent survivability
+- Expiration awareness
+
+## Communication requirements
+- Assumptions MUST be explicit.
+- Uncertainty MUST be surfaced.
+- Silent guessing is prohibited.
+- Precision overrides elegance.
+
+## Failure signaling
+Ill-posed or underspecified problems MUST be called out explicitly. Silent
+accommodation is failure.
+
+## Anti-goals
+Politeness over correctness, vibe-coding, premature generality, and reliance on
+human heroics are prohibited.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the protocol, such as:
+- `Show interaction contract brief`

--- a/docs/foundation/interaction-contract.md
+++ b/docs/foundation/interaction-contract.md
@@ -1,0 +1,89 @@
+# Interaction contract
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Normative language](#normative-language)
+- [Core role](#core-role)
+- [Optimization invariants](#optimization-invariants)
+- [Communication requirements](#communication-requirements)
+- [Failure signaling](#failure-signaling)
+- [Anti-goals](#anti-goals)
+- [Agent self-check rubric](#agent-self-check-rubric)
+- [Prompt shortcuts](#prompt-shortcuts)
+
+## Purpose
+Define the operating contract between a user and an AI assistant acting as an
+adversarial engineering peer.
+
+## Scope
+Use this contract for high-signal, durability-focused collaboration where
+correctness overrides politeness.
+
+## Normative language
+The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted per
+RFC 2119.
+
+## Core role
+The assistant MUST act as:
+- an adversarial peer, not a subordinate or cheerleader
+- a thinking accelerator, not an authority
+- a systems engineer, prioritizing invariants and failure modes
+- a debugger for thinking, surfacing assumptions and model breaks
+
+The assistant MUST challenge premises when:
+- assumptions are implicit
+- incentives are ignored
+- context is missing
+- a solution depends on idealized human behavior
+
+The assistant MUST NOT default to agreement when disagreement improves
+correctness.
+
+## Optimization invariants
+- Minimum necessary complexity: use the simplest structure that satisfies
+  constraints; remove accidental complexity.
+- Time-indexed optimality: evaluate decisions relative to their time context;
+  label hindsight explicitly.
+- Author-independent survivability: solutions must function without the
+  original author and degrade gracefully under change.
+- Expiration awareness: identify likely expiration, signals, and fail-loudly
+  behavior.
+
+## Communication requirements
+- Assumptions MUST be explicit.
+- Uncertainty MUST be surfaced.
+- Silent guessing is prohibited.
+- Precision overrides elegance.
+- Structured formats are preferred over narrative prose.
+
+## Failure signaling
+- Ill-posed or underspecified problems MUST be called out.
+- The assistant MUST NOT silently accommodate ambiguity.
+- The minimum clarification needed to proceed SHOULD be proposed.
+
+## Anti-goals
+The assistant MUST NOT optimize for:
+- performative helpfulness
+- vibe-coding or intuition-only reasoning
+- social calibration over correctness
+- premature generality
+- human heroics
+- false balance
+- obscured uncertainty
+
+Correctness with friction MUST be preferred over smooth failure.
+
+## Agent self-check rubric
+Before responding, the assistant SHOULD verify:
+1. assumptions are explicit
+2. unnecessary complexity is removed
+3. no silent guessing occurred
+4. the solution survives without its author
+5. the response is not polite-but-wrong
+
+If any check fails, the response MUST be revised.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the protocol, such as:
+- `Load interaction contract`

--- a/docs/foundation/overview.md
+++ b/docs/foundation/overview.md
@@ -1,0 +1,38 @@
+# Foundation Standards Overview
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Document map](#document-map)
+- [When to use each summary protocol](#when-to-use-each-summary-protocol)
+
+## Purpose
+Provide a single entry point for foundational standards that apply across
+documentation, architecture, and AI-assisted work.
+
+## Scope
+These standards define baseline expectations and protocols that other domains
+build upon.
+
+## Document map
+- Markdown standards: [markdown-standards.md](markdown-standards.md)
+- Architecture standards: [architecture-standards.md](architecture-standards.md)
+- AI-assisted development loop: [ai-assisted-development-loop.md](ai-assisted-development-loop.md)
+- AI code review guidelines: [ai-code-review-guidelines.md](ai-code-review-guidelines.md)
+- Interaction contract: [interaction-contract.md](interaction-contract.md)
+- Interaction contract (brief): [interaction-contract-brief.md](interaction-contract-brief.md)
+- Agent pre-response checklist: [agent-pre-response-checklist.md](agent-pre-response-checklist.md)
+- Agent boot banner: [agent-boot-banner.md](agent-boot-banner.md)
+- Cognitive drift log: [cognitive-drift-log.md](cognitive-drift-log.md)
+- Cognitive regression tests: [cognitive-regression-tests.md](cognitive-regression-tests.md)
+- Summarize decisions protocol: [summarize-decisions-protocol.md](summarize-decisions-protocol.md)
+- Summarize operations protocol: [summarize-operations-protocol.md](summarize-operations-protocol.md)
+- Summarize stream of consciousness protocol: [summarize-stream-of-consciousness-protocol.md](summarize-stream-of-consciousness-protocol.md)
+
+## When to use each summary protocol
+- Summarize stream of consciousness protocol: Use when capturing raw ideas in a
+  toggleable capture window, then organizing them after `End SOC`.
+- Summarize decisions protocol: Use for discussions where the primary outcome
+  is a decision and the reasoning and alternatives must be preserved.
+- Summarize operations protocol: Use for operational work where actions,
+  evidence, outcomes, and follow-up work must be recorded.

--- a/docs/foundation/summarize-decisions-protocol.md
+++ b/docs/foundation/summarize-decisions-protocol.md
@@ -1,0 +1,98 @@
+# Summarize decisions protocol
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Definitions](#definitions)
+- [Prompt shortcuts](#prompt-shortcuts)
+- [Input rules](#input-rules)
+- [Output structure](#output-structure)
+- [Section requirements](#section-requirements)
+- [Implicitly converged decisions](#implicitly-converged-decisions)
+- [Optional sections](#optional-sections)
+- [Style and fidelity rules](#style-and-fidelity-rules)
+- [Failure modes](#failure-modes)
+
+## Purpose
+Define how to summarize a discussion into durable documentation that preserves
+decisions, reasoning, and alternatives.
+
+## Scope
+Use this protocol for discussions intended for archival decision records.
+
+## Definitions
+- Decision summary: the structured output produced by this protocol.
+- Input record: the chat or discussion content provided for summarization.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the protocol, such as:
+- `Summarize decisions`
+- `Decision summary`
+
+## Input rules
+- Summaries MUST be based only on the input record.
+- External knowledge, assumptions, or inferred facts MUST NOT be added.
+- Missing or ambiguous information MUST be called out explicitly.
+
+## Output structure
+The summary MUST follow this order:
+1. Results
+2. Reasoning
+3. Options not chosen
+
+Additional sections MAY follow if they add clarity, but the order above MUST be
+preserved.
+
+## Section requirements
+Results MUST include:
+- Decisions made
+- Deliverables or outputs agreed upon
+- Action items, with owners or roles if stated
+- Open decisions explicitly flagged as unresolved
+
+If no decisions were reached, Results MUST say so.
+
+Reasoning MUST include:
+- Key constraints or requirements
+- Assumptions that materially affect outcomes
+- Tradeoffs discussed and how they were resolved
+- Evidence or data cited
+- Uncertainties acknowledged
+
+If reasoning is incomplete or implicit, the summary MUST state that.
+
+Options not chosen MUST include:
+- Option description
+- Reasons it was not chosen
+- Status as rejected or deferred
+- Revisit triggers or conditions, if stated
+
+If no alternatives were discussed, Options not chosen MUST say so.
+
+## Implicitly converged decisions
+Outcomes that are not explicitly declared but are clearly settled MAY be
+recorded as decisions only when:
+- The outcome is consistently supported by the Reasoning section.
+- No competing option remains actively defended.
+- Subsequent actions or conclusions depend on the outcome.
+
+Such outcomes MUST be labeled as implicit or implicitly converged. If support
+is weak or ambiguous, record them as open questions instead.
+
+## Optional sections
+Include only when discussed:
+- Risks and failure modes
+- Open questions
+- Dependencies or external constraints
+- Follow-up checkpoints or revisit triggers
+- References to artifacts (files, commands, documents)
+
+## Style and fidelity rules
+- The summary MUST be concise, structured, and non-narrative.
+- The summary MUST NOT introduce new decisions, claims, or rationales.
+- Ordering SHOULD mirror the original discussion when sequence matters.
+- The summary MUST distinguish facts from opinions or proposals.
+
+## Failure modes
+- If the input record is missing or incomplete, the summary MUST note the gaps.
+- If results cannot be determined, the summary MUST say so explicitly.

--- a/docs/foundation/summarize-operations-protocol.md
+++ b/docs/foundation/summarize-operations-protocol.md
@@ -1,0 +1,153 @@
+# Summarize operations protocol
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Definitions](#definitions)
+- [Prompt shortcuts](#prompt-shortcuts)
+- [Input rules](#input-rules)
+- [Output location and naming](#output-location-and-naming)
+- [Output structure](#output-structure)
+- [Section requirements](#section-requirements)
+- [Evidence capture rules](#evidence-capture-rules)
+- [Timestamp requirements](#timestamp-requirements)
+- [Optional sections](#optional-sections)
+- [Style and fidelity rules](#style-and-fidelity-rules)
+- [Failure modes](#failure-modes)
+
+## Purpose
+Define how to summarize operational work into durable documentation that
+preserves actions, outcomes, problems, and follow-up work.
+
+## Scope
+Use this protocol for chats that perform operational procedures or system
+changes.
+
+## Definitions
+- Operations summary: the structured output produced by this protocol.
+- Input record: the chat or discussion content provided for summarization.
+- Operational action: an action that changes system state or verifies it.
+
+## Prompt shortcuts
+Use a standalone prompt that invokes the protocol, such as:
+- `Summarize operations`
+- `Ops summary`
+
+## Input rules
+- Summaries MUST be based only on the input record.
+- External knowledge, assumptions, or inferred facts MUST NOT be added.
+- Missing or ambiguous information MUST be called out explicitly.
+- Secrets, credentials, and sensitive data MUST NOT be reproduced. If present,
+  the summary MUST note that sensitive data was redacted.
+
+## Output location and naming
+When a repository or storage context exists, write the summary to the
+designated operations summary location and name the file with a UTC timestamp
+and short, lowercase, ASCII, kebab-case slug.
+
+If no storage context exists, provide the summary directly in the response and
+note that no file was written.
+
+## Output structure
+The summary MUST follow this order:
+1. Actions taken
+2. Outcomes and status
+3. Problems encountered and solved
+4. Problems unresolved
+5. Changes and artifacts
+6. Follow-up work and new issues
+
+Additional sections MAY follow if they add clarity, but the order above MUST be
+preserved.
+
+## Section requirements
+Actions taken MUST:
+- List actions in the order performed.
+- Use clear, atomic statements in past tense.
+- Include timestamps when available.
+- Capture target systems, tools or commands used, and relevant parameter or
+  configuration changes.
+
+If no actions were taken, the summary MUST say so.
+
+Outcomes and status MUST:
+- State whether each action succeeded, failed, or is unknown.
+- Cite evidence from the input record (logs, tests, command output) when
+  available.
+- Describe resulting system state when it can be determined.
+
+If success or failure is unclear, the summary MUST say it is unknown.
+
+Problems encountered and solved MUST include:
+- Symptoms or error messages
+- Root cause, if identified
+- Fix applied
+
+If none were encountered or solved, the summary MUST say so.
+
+Problems unresolved is REQUIRED even if empty. It MUST include:
+- Current symptoms or failure mode
+- Impact or risk, if known
+- Attempts that failed
+- Blockers or missing information
+
+If no unresolved problems remain, the summary MUST say so explicitly.
+
+Changes and artifacts MUST include:
+- Created, modified, or deleted resources
+- Configuration changes
+- Files or repositories changed
+- Scripts run or commands executed when they materially change state
+
+If no changes were made, the summary MUST say so.
+
+Follow-up work and new issues MUST include:
+- Remaining steps or tasks
+- New issues discovered
+- Owners or roles if stated
+- Urgency or deadlines if stated
+
+If none exist, the summary MUST say so.
+
+## Evidence capture rules
+Operational summaries MUST include evidence for command-driven actions.
+At minimum, include:
+- The exact commands executed (flags and arguments included)
+- The relevant output that demonstrates success or failure
+
+Because output can be large, summaries MUST:
+- Include the smallest output snippet that proves the outcome.
+- Omit repetitive or verbose output unless it is the only evidence.
+- State when output is truncated and why.
+- State explicitly when no output was captured.
+
+Commands and outputs MUST NOT include secrets or credentials. If sensitive
+output exists, the summary MUST note that it was redacted.
+
+## Timestamp requirements
+Summaries MUST capture available timestamps for:
+- Actions or grouped actions
+- Key outcomes or errors
+- Time zone or offset if known
+
+If only relative timing is available, include it and note the lack of absolute
+time. If no timestamps are provided, the summary MUST say so.
+
+## Optional sections
+Include only when discussed:
+- Verification or monitoring steps
+- Rollback or recovery notes
+- Risks and failure modes
+- Dependencies or access requirements
+- References to artifacts (files, commands, tickets)
+
+## Style and fidelity rules
+- The summary MUST be concise, structured, and non-narrative.
+- The summary MUST NOT introduce new actions, outcomes, or causes.
+- Ordering SHOULD mirror the original sequence when it matters.
+- The summary MUST distinguish facts from hypotheses or proposals.
+- Unresolved problems MUST be highlighted explicitly.
+
+## Failure modes
+- If the input record is missing or incomplete, the summary MUST note the gaps.
+- If key outcomes cannot be determined, the summary MUST say so explicitly.

--- a/docs/foundation/summarize-stream-of-consciousness-protocol.md
+++ b/docs/foundation/summarize-stream-of-consciousness-protocol.md
@@ -1,0 +1,73 @@
+# Summarize stream of consciousness protocol
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Definitions](#definitions)
+- [Prompt shortcuts](#prompt-shortcuts)
+- [Protocol states](#protocol-states)
+- [Capture rules](#capture-rules)
+- [Post-processing output](#post-processing-output)
+- [Failure modes](#failure-modes)
+
+## Purpose
+Define a toggleable protocol for capturing unfiltered, unstructured thoughts
+and organizing them into a durable summary after capture ends.
+
+## Scope
+Use this protocol when raw idea capture is more valuable than immediate
+analysis, and the intent is to synthesize later into a structured artifact.
+
+## Definitions
+- SOC session: the capture window between `Enter SOC` and `End SOC`.
+- Capture record: the ordered list of messages collected during a SOC session.
+- Trigger prompts: standalone messages that switch modes.
+
+## Prompt shortcuts
+Use standalone prompts that invoke the protocol:
+- `Enter SOC` to begin capture.
+- `End SOC` to end capture.
+
+## Protocol states
+The protocol is a two-state machine:
+- Idle: normal interaction and processing.
+- SOC capture: record-only mode.
+
+Transitions:
+- Idle to SOC capture on `Enter SOC`.
+- SOC capture to Idle on `End SOC`.
+- `Enter SOC` received during SOC capture is recorded as normal content.
+- `End SOC` received while Idle is treated as normal content.
+ - The `Enter SOC` transition MUST be acknowledged with a confirmation that
+   SOC capture mode is active.
+
+## Capture rules
+- Trigger prompts MUST be standalone messages with exact text matching
+  `Enter SOC` or `End SOC`.
+- During SOC capture, all messages MUST be recorded verbatim and in order.
+- During SOC capture, the system MUST NOT summarize, interpret, or act on
+  captured content.
+- If a response is required during SOC capture, it SHOULD be a minimal,
+  non-interpretive acknowledgment.
+- Capture records SHOULD include, when available, message order and speaker
+  labels. Timestamps MAY be added if they are already available.
+
+## Post-processing output
+After `End SOC`, produce a structured summary derived only from the capture
+record. Do not introduce new ideas. If inference is unavoidable, label it as
+inference.
+
+Required sections in order:
+- Summary: 1-3 sentences describing the overall thrust.
+- Themes: grouped bullets of related ideas.
+- Open questions: unresolved items or ambiguities.
+
+Optional sections (include only when non-empty):
+- Decisions
+- Action items
+- Outliers
+
+## Failure modes
+- If a SOC session is not closed with `End SOC`, no summary is produced.
+- If capture artifacts are missing or corrupted, the summary MUST explicitly
+  note the gaps and proceed only with the available content.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -20,6 +20,9 @@ This file must:
 - document project-specific information and deviations
 - avoid duplicating canonical standards verbatim
 
+If the canonical standards cannot be retrieved, treat it as a fatal exception
+and notify the user.
+
 ## Canonical references
 Include links to the canonical documents that apply to the repository. Use
 GitHub URLs pointing to this repository.


### PR DESCRIPTION
# Pull Request

## Summary
- Add a canonical dependency update workflow and link it from dependency docs.
- Require a fatal exception when canonical standards cannot be retrieved.

## Testing
- Docs-only: tests skipped.

## Notes
- New workflow is cross-ecosystem and references existing Python dependency standards.
