### PR TITLE
docs: add shared skills and agent snippets

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,44 @@
+# Skills overview
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Skill list](#skill-list)
+- [Usage conventions](#usage-conventions)
+- [Downstream references](#downstream-references)
+
+## Purpose
+Provide a canonical, repository-managed set of Codex skills derived from the
+standards in this repository.
+
+## Scope
+These skills are shared across repositories that adopt the standards here.
+Skill bodies must remain aligned with the canonical documents they reference.
+
+## Skill list
+- `summarize` (`skills/summarize/SKILL.md`): multi-mode summarization for
+  decisions, operations, and SOC capture.
+- `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow with
+  docs-only exception handling.
+- `dependency-update` (`skills/dependency-update/SKILL.md`): dependency update
+  workflow with failure handling and anchor rules.
+- `deprecation-triage` (`skills/deprecation-triage/SKILL.md`): deprecation
+  warning triage workflow and issue template.
+
+## Usage conventions
+- Keep skills minimal and procedural; defer rationale to the standards.
+- Update skills when the referenced standards change.
+- Do not duplicate standards verbatim; link to canonical docs instead.
+
+## Downstream references
+Add a short reference to these skills in downstream `AGENTS.md` files using
+placeholders for the local path to the standards repository.
+
+Example snippet (replace placeholders):
+```
+## Shared skills
+- summarize: <standards-repo-path>/skills/summarize/SKILL.md
+- pr-workflow: <standards-repo-path>/skills/pr-workflow/SKILL.md
+- dependency-update: <standards-repo-path>/skills/dependency-update/SKILL.md
+- deprecation-triage: <standards-repo-path>/skills/deprecation-triage/SKILL.md
+```

--- a/skills/agents-snippets.md
+++ b/skills/agents-snippets.md
@@ -1,0 +1,26 @@
+# AGENTS.md snippets for shared skills
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Snippet](#snippet)
+- [Notes](#notes)
+
+## Purpose
+Provide a reusable snippet that downstream repositories can copy into their
+`AGENTS.md` to reference these shared skills.
+
+## Snippet
+Replace `<standards-repo-path>` with the local path to the cloned standards
+repository.
+
+```
+## Shared skills
+- summarize: <standards-repo-path>/skills/summarize/SKILL.md
+- pr-workflow: <standards-repo-path>/skills/pr-workflow/SKILL.md
+- dependency-update: <standards-repo-path>/skills/dependency-update/SKILL.md
+- deprecation-triage: <standards-repo-path>/skills/deprecation-triage/SKILL.md
+```
+
+## Notes
+- Keep this list in sync with `skills/README.md`.
+- Do not duplicate skill contents in downstream repositories.

--- a/skills/dependency-update/SKILL.md
+++ b/skills/dependency-update/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: dependency-update
+description: Run the dependency update workflow with validation, failure handling, and anchor record requirements.
+---
+
+# Dependency update
+
+## Table of Contents
+- [Overview](#overview)
+- [Preflight](#preflight)
+- [Workflow](#workflow)
+- [Failure handling](#failure-handling)
+- [Completion](#completion)
+- [Resources](#resources)
+
+## Overview
+Execute a repeatable dependency update process that prioritizes stability and
+traceability. Use language-specific standards when present.
+
+## Preflight
+- Identify the relevant dependency standards for the repository.
+- Confirm sources of truth for dependency versions and lockfiles.
+- If the repository defines a canonical validation command, capture it.
+
+## Workflow
+1. Collect update signals (security alerts, audits, planned upgrades).
+2. Update dependencies at their sources of truth.
+3. Regenerate derived artifacts (lockfiles, exports, or generated manifests).
+4. Run the full validation and test suite.
+5. Proceed through the standard pull request workflow.
+
+## Failure handling
+- Determine root cause before pinning or deferring.
+- If a dependency is anchored below the latest acceptable range:
+  - Create or update an anchored dependency record.
+  - Document the failure evidence and exit criteria.
+- If the dependency itself is the blocker, create a tracking issue and record
+  the pin rationale at the source of truth.
+
+## Completion
+- Ensure the repository is in a clean, validated state.
+- Record any new anchors, issues, or follow-up actions.
+
+## Resources
+- `docs/dependencies/dependency-update-workflow.md`
+- `docs/dependencies/overview.md`
+- `docs/development/python/dependency-management.md` (when applicable)
+- `docs/code-management/pull-request-workflow.md`

--- a/skills/deprecation-triage/SKILL.md
+++ b/skills/deprecation-triage/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: deprecation-triage
+description: Triage deprecation warnings into a consistent workflow with issue tracking and suppression rules.
+---
+
+# Deprecation triage
+
+## Table of Contents
+- [Overview](#overview)
+- [Inputs](#inputs)
+- [Workflow](#workflow)
+- [Issue template](#issue-template)
+- [Resources](#resources)
+
+## Overview
+Apply the deprecation warning triage policy to prevent warning drift and ensure
+issues are tracked and resolved in-cycle or deferred explicitly.
+
+## Inputs
+Collect or request:
+- Full warning text
+- Location (file/module and call site)
+- Environment (dev/test/prod)
+- First seen date and version
+- Whether the warning is user-visible
+
+## Workflow
+1. Search for an existing issue that matches the warning text and location.
+2. If an issue exists and the warning is mid-cycle, defer to the next
+   dependency update.
+3. If no issue exists, create one using the template below.
+4. Attempt a code-only fix if no dependency upgrade is required.
+5. If a dependency upgrade is required, defer to the start-of-cycle upgrade.
+6. If user-visible and deferred, suppress and document the suppression.
+7. Update the issue with each re-test and close when resolved.
+
+## Issue template
+```
+Title: Deprecation: <dependency or component> - <short description>
+
+Warning text:
+<full warning message>
+
+Location:
+- file/module:
+- call site:
+- environment (dev/test/prod):
+
+Reproduction:
+- minimal command or steps:
+- notes on reproducibility:
+
+First seen:
+- date:
+- version:
+
+Impact assessment:
+- user-visible: yes/no
+- behavior risk:
+
+Attempted fixes:
+- code changes tried:
+- result:
+
+Upgrade assessment:
+- required dependency version:
+- upgrade scope:
+
+Decision:
+- fix now / defer to next cycle
+- rationale:
+
+Suppression (if any):
+- suppression method:
+- removal criteria:
+```
+
+## Resources
+- `docs/development/deprecation-warnings.md`

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr-workflow
+description: Guide pull request creation, submission, and finalization using the canonical PR workflow, including the docs-only exception.
+---
+
+# PR workflow
+
+## Table of Contents
+- [Overview](#overview)
+- [Preflight](#preflight)
+- [Docs-only determination](#docs-only-determination)
+- [Pre-submission steps](#pre-submission-steps)
+- [Submission and finalization](#submission-and-finalization)
+- [Resources](#resources)
+
+## Overview
+Execute the pull request workflow with required validations and checkpoints.
+Follow local overrides (AGENTS or repo-specific standards) when present.
+
+## Preflight
+- Confirm you are working on a short-lived branch per branching rules.
+- Locate the pull request template at `.github/pull_request_template.md`.
+- Ensure commit message format and AI co-authorship requirements are met per
+  the commit standards and the repo's approved AI identity list.
+
+## Docs-only determination
+- Identify whether the change set is "docs-only" as defined by the repository.
+- If the repository does not define a docs-only rule, ask for it before
+  applying the exception.
+- When using the docs-only exception, include `Docs-only: tests skipped` in the
+  PR description and list the files changed.
+
+## Pre-submission steps
+1. Run the repository's canonical validation command if documented.
+2. If no canonical command exists, ask for the required validation steps.
+3. If any check fails, do not submit the PR; fix and rerun the full checks.
+4. Populate the pull request template fields.
+5. Include issue linkage when required.
+
+## Submission and finalization
+- Submit the PR only after all required checks pass (unless docs-only
+  exception applies).
+- Follow repository-specific confirmation checkpoints if defined in AGENTS.
+- After merge approval, finalize in order:
+  1. Merge the PR and delete the remote branch.
+  2. Update the local copy of the target branch.
+  3. Synchronize the local environment with dependency specifications.
+  4. Delete the local feature branch and prune stale remotes.
+  5. Run final validation (skip for docs-only PRs).
+
+## Resources
+- `docs/code-management/pull-request-workflow.md`
+- `docs/code-management/branching-and-deployment.md`
+- `docs/code-management/commit-messages-and-authorship.md`
+- `docs/standards-and-conventions.md`

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: summarize
+description: Multi-mode summarization for decisions, operations, or stream-of-consciousness capture. Use when the user asks for a structured summary or invokes SOC capture.
+---
+
+# Summarize
+
+## Table of Contents
+- [Overview](#overview)
+- [Mode selection](#mode-selection)
+- [Common rules](#common-rules)
+- [Mode: decisions](#mode-decisions)
+- [Mode: operations](#mode-operations)
+- [Mode: soc](#mode-soc)
+- [Output templates](#output-templates)
+- [Resources](#resources)
+
+## Overview
+Produce a concise, structured summary using the canonical protocol for the
+selected mode. Preserve outcomes, reasoning, and evidence without adding
+external knowledge.
+
+## Mode selection
+Select the mode in this order:
+1. If the user explicitly specifies a mode, follow it.
+2. If the user uses `Enter SOC` or `End SOC`, use **soc** mode.
+3. If the request centers on decisions, rationale, or alternatives, use
+   **decisions** mode.
+4. If the request centers on actions taken, system changes, or outcomes, use
+   **operations** mode.
+5. If multiple modes plausibly apply, ask the minimum clarification question:
+   "Which mode: decisions, operations, or soc?"
+
+## Common rules
+- Base the summary only on the provided input record.
+- Do not add external facts, assumptions, or inferred details.
+- Call out missing or ambiguous information explicitly.
+- Preserve sequence when the order of events matters.
+- Keep the output concise and non-narrative.
+
+## Mode: decisions
+Follow the Summarize Decisions Protocol.
+- Required section order: Results, Reasoning, Options Not Chosen.
+- Label implicitly converged decisions as **implicit**.
+- Include optional sections only when present in the input.
+
+## Mode: operations
+Follow the Summarize Operations Protocol.
+- Required section order: Actions Taken, Outcomes and Status, Problems
+  Encountered and Solved, Problems Unresolved, Changes and Artifacts, Follow-up
+  Work and New Issues.
+- Capture evidence for command-driven actions (commands + minimal output).
+- Include timestamps when available; state when none were provided.
+- Redact secrets or sensitive data and note the redaction.
+
+## Mode: soc
+Follow the Summarize Stream of Consciousness Protocol.
+- `Enter SOC` begins capture mode; acknowledge capture activation.
+- During SOC capture, record input verbatim and do not summarize or interpret.
+- `End SOC` ends capture mode and triggers the structured summary.
+- If SOC is not closed with `End SOC`, do not produce a summary.
+
+## Output templates
+Decisions:
+```
+Results
+- ...
+
+Reasoning
+- ...
+
+Options Not Chosen
+- Option: ...
+  Reason: ...
+  Status: rejected | deferred
+  Revisit triggers: ...
+```
+
+Operations:
+```
+Actions Taken
+- ...
+
+Outcomes and Status
+- ...
+
+Problems Encountered and Solved
+- ...
+
+Problems Unresolved
+- ...
+
+Changes and Artifacts
+- ...
+
+Follow-up Work and New Issues
+- ...
+```
+
+SOC:
+```
+Summary
+- ...
+
+Themes
+- ...
+
+Open Questions
+- ...
+```
+
+## Resources
+- `docs/foundation/summarize-decisions-protocol.md`
+- `docs/foundation/summarize-operations-protocol.md`
+- `docs/foundation/summarize-stream-of-consciousness-protocol.md`


### PR DESCRIPTION
# Pull Request

## Summary
- Add repo-managed skill definitions for summarization, PR workflow, dependency updates, and deprecation triage.
- Add a shared skills index plus downstream AGENTS.md snippet guidance.

## Issue Linkage
- None.
- Work is not complete until the issue is closed.
- If no issue exists, state why and open one before merge.

## Testing
- Docs-only: tests skipped.

## Notes
Docs-only: tests skipped. Files changed:
- skills/README.md
- skills/agents-snippets.md
- skills/summarize/SKILL.md
- skills/pr-workflow/SKILL.md
- skills/dependency-update/SKILL.md
- skills/deprecation-triage/SKILL.md
