### PR TITLE
docs: add summarize wrapper skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -18,6 +18,12 @@ Skill bodies must remain aligned with the canonical documents they reference.
 ## Skill list
 - `summarize` (`skills/summarize/SKILL.md`): multi-mode summarization for
   decisions, operations, and SOC capture.
+- `summarize-decisions` (`skills/summarize-decisions/SKILL.md`): wrapper for
+  decisions summaries (autocomplete-friendly).
+- `summarize-operations` (`skills/summarize-operations/SKILL.md`): wrapper for
+  operations summaries (autocomplete-friendly).
+- `summarize-soc` (`skills/summarize-soc/SKILL.md`): wrapper for SOC capture
+  summaries (autocomplete-friendly).
 - `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow with
   docs-only exception handling.
 - `dependency-update` (`skills/dependency-update/SKILL.md`): dependency update

--- a/skills/agents-snippets.md
+++ b/skills/agents-snippets.md
@@ -16,6 +16,9 @@ repository.
 ```
 ## Shared skills
 - summarize: <standards-repo-path>/skills/summarize/SKILL.md
+- summarize-decisions: <standards-repo-path>/skills/summarize-decisions/SKILL.md
+- summarize-operations: <standards-repo-path>/skills/summarize-operations/SKILL.md
+- summarize-soc: <standards-repo-path>/skills/summarize-soc/SKILL.md
 - pr-workflow: <standards-repo-path>/skills/pr-workflow/SKILL.md
 - dependency-update: <standards-repo-path>/skills/dependency-update/SKILL.md
 - deprecation-triage: <standards-repo-path>/skills/deprecation-triage/SKILL.md

--- a/skills/summarize-decisions/SKILL.md
+++ b/skills/summarize-decisions/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: summarize-decisions
+description: Summarize discussions using the decisions protocol (wrapper for summarize mode=decisions).
+---
+
+# Summarize decisions
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Workflow](#workflow)
+- [Output structure](#output-structure)
+- [Resources](#resources)
+
+## Purpose
+Provide a decisions-focused summary using the canonical decisions protocol.
+
+## Workflow
+- Use the decisions protocol and do not add external facts.
+- If the input is ambiguous or incomplete, call it out explicitly.
+- Treat implicitly converged decisions as **implicit**.
+
+## Output structure
+Required order:
+1. Results
+2. Reasoning
+3. Options Not Chosen
+
+Include optional sections only when present in the input.
+
+## Resources
+- `skills/summarize/SKILL.md`
+- `docs/foundation/summarize-decisions-protocol.md`

--- a/skills/summarize-operations/SKILL.md
+++ b/skills/summarize-operations/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: summarize-operations
+description: Summarize operational work using the operations protocol (wrapper for summarize mode=operations).
+---
+
+# Summarize operations
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Workflow](#workflow)
+- [Output structure](#output-structure)
+- [Resources](#resources)
+
+## Purpose
+Provide an operations-focused summary using the canonical operations protocol.
+
+## Workflow
+- Use the operations protocol and do not add external facts.
+- Capture evidence for command-driven actions when available.
+- Include timestamps when available; state when none were provided.
+- Redact sensitive data and note the redaction.
+
+## Output structure
+Required order:
+1. Actions Taken
+2. Outcomes and Status
+3. Problems Encountered and Solved
+4. Problems Unresolved
+5. Changes and Artifacts
+6. Follow-up Work and New Issues
+
+## Resources
+- `skills/summarize/SKILL.md`
+- `docs/foundation/summarize-operations-protocol.md`

--- a/skills/summarize-soc/SKILL.md
+++ b/skills/summarize-soc/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: summarize-soc
+description: Capture and summarize stream-of-consciousness input using the SOC protocol (wrapper for summarize mode=soc).
+---
+
+# Summarize SOC
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Workflow](#workflow)
+- [Output structure](#output-structure)
+- [Resources](#resources)
+
+## Purpose
+Provide a stream-of-consciousness capture and summary using the canonical SOC
+protocol.
+
+## Workflow
+- `Enter SOC` starts capture mode and must be acknowledged.
+- During capture, record input verbatim and do not interpret.
+- `End SOC` ends capture and triggers the structured summary.
+- If capture is never closed, do not summarize.
+
+## Output structure
+Required sections:
+- Summary
+- Themes
+- Open Questions
+
+Include optional sections only when present in the input.
+
+## Resources
+- `skills/summarize/SKILL.md`
+- `docs/foundation/summarize-stream-of-consciousness-protocol.md`


### PR DESCRIPTION
# Pull Request

## Summary
- Add summarize wrapper skills for decisions, operations, and SOC modes.
- Update shared skills index and AGENTS.md snippet to include wrappers.

## Issue Linkage
- None.
- Work is not complete until the issue is closed.
- If no issue exists, state why and open one before merge.

## Testing
- Docs-only: tests skipped.

## Notes
Docs-only: tests skipped. Files changed:
- skills/README.md
- skills/agents-snippets.md
- skills/summarize-decisions/SKILL.md
- skills/summarize-operations/SKILL.md
- skills/summarize-soc/SKILL.md
