### PR TITLE
docs: require python3 and venv activation

### DIFF
--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Purpose](#purpose)
 - [Virtual Environment Requirement](#virtual-environment-requirement)
+- [Python invocation and venv activation](#python-invocation-and-venv-activation)
 - [External Tooling Dependencies](#external-tooling-dependencies)
 - [Maintenance](#maintenance)
 
@@ -18,6 +19,21 @@ Rationale:
 - ensures consistent dependency resolution
 - avoids system runtime drift
 - prevents local versus CI mismatches
+
+## Python invocation and venv activation
+Rules:
+- Use `python3` for all Python invocations. `python` is forbidden.
+- Treat a repository as Python if it contains `pyproject.toml`,
+  `requirements*.txt`, `setup.cfg`, `setup.py`, or documentation that declares
+  Python usage.
+- For Python repositories, activate the project-specific environment before
+  running any Python command (application code, tests, utility scripts, or
+  ad hoc invocations).
+- If a Python repository does not define a project-specific environment, stop
+  and establish one before running Python commands.
+- For non-Python repositories, do not assume Python is available. If Python is
+  required for tooling, create a dedicated environment and document it in the
+  external tooling list.
 
 ## External Tooling Dependencies
 Each repository must maintain a minimal, explicit list of required external

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -19,6 +19,8 @@ and long-term survivability across repositories.
 - Default linting: ruff.
 - Default type checking: mypy in strict mode.
 - If a repository uses different tools, document the reason and equivalents.
+- Invoke Python as `python3` and use a project-specific environment for all
+  Python commands. See `docs/development/environment-and-tooling.md`.
 
 ## Document Map
 - Naming conventions: [naming-conventions.md](naming-conventions.md)


### PR DESCRIPTION
# Pull Request

## Summary
- Require `python3` for all Python invocations.
- Require project-specific environment activation for Python repos.
- Clarify detection signals and non-Python repo guidance.

## Issue Linkage
- None.
- Work is not complete until the issue is closed.
- If no issue exists, state why and open one before merge.

## Testing
- Docs-only: tests skipped.

## Notes
Docs-only: tests skipped. Files changed:
- docs/development/environment-and-tooling.md
- docs/development/python/overview.md
