### PR TITLE
docs: add python CI gate standards

### DIFF
--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -4,6 +4,7 @@
 - [Purpose](#purpose)
 - [Core Principles](#core-principles)
 - [Tooling Expectations](#tooling-expectations)
+- [CI Gates](#ci-gates)
 - [Document Map](#document-map)
 
 ## Purpose
@@ -21,6 +22,30 @@ and long-term survivability across repositories.
 - If a repository uses different tools, document the reason and equivalents.
 - Invoke Python as `python3` and use a project-specific environment for all
   Python commands. See `docs/development/environment-and-tooling.md`.
+
+## CI Gates
+Every CI check is classified as a hard gate or soft gate.
+
+Hard gate definition:
+- Merge-blocking. A required status check must be configured on the target
+  branch. Any failure blocks merge until a new commit passes.
+
+Soft gate definition:
+- Warning-only. The check can fail without blocking merge, but failures must be
+  surfaced with rationale and follow-up tracking when applicable.
+
+Hard gates (all are required status checks):
+- `test-and-validate (3.14)`
+- `integration-tests`
+- `dependency-audit`
+
+Soft gates:
+- None (default to hard gate until documented).
+
+Branch applicability:
+- develop: all hard gates required
+- release: all hard gates required
+- main: all hard gates required
 
 ## Document Map
 - Naming conventions: [naming-conventions.md](naming-conventions.md)


### PR DESCRIPTION
## Summary
- Define hard vs soft CI gates for Python repositories.
- Record the required hard gate checks and branch applicability.

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/development/python/overview.md
