### PR TITLE
docs: require issue acceptance criteria

### DIFF
--- a/docs/code-management/github-issues.md
+++ b/docs/code-management/github-issues.md
@@ -5,6 +5,7 @@
 - [Scope](#scope)
 - [Definitions](#definitions)
 - [Core rules](#core-rules)
+- [Acceptance criteria](#acceptance-criteria)
 - [Issue creation and linking](#issue-creation-and-linking)
 - [Sub-issues](#sub-issues)
 - [Closing behavior](#closing-behavior)
@@ -29,12 +30,24 @@ Applies to all repositories that use GitHub issues and pull requests.
 - One primary issue per pull request. If a PR must close multiple issues,
   document why in the PR description.
 
+## Acceptance criteria
+Every issue must specify acceptance criteria if they are not intuitively
+obvious. If acceptance criteria are ambiguous, get explicit human confirmation
+before proceeding.
+
+Examples:
+- Docs-only issues: satisfied when documentation changes are merged.
+- Bug reports: may require reporter confirmation or verified reproduction and
+  resolution steps.
+
 ## Issue creation and linking
 - If a human already specified an issue, use it as the primary issue.
 - If no issue exists, create one before creating a branch or changing files.
 - The PR description must link to the primary issue.
-- Use a closing keyword in the PR description only when the PR should close
-  the issue. Use a non-closing reference when it should not.
+- If an issue has no special acceptance criteria, include a closing keyword in
+  the PR description so the issue auto-closes on merge.
+- If acceptance criteria are specified, use a non-closing reference in the PR
+  description and close the issue only when the criteria are satisfied.
 
 ## Sub-issues
 Create a sub-issue when:
@@ -48,10 +61,12 @@ Sub-issue rules:
   the parent’s full scope.
 
 ## Closing behavior
-- Use closing keywords in PR descriptions to auto-close issues when the PR
-  should resolve them.
+- Default: auto-close issues via PR closing keywords.
+- If acceptance criteria are specified, do not auto-close. The agent
+  finalizing the PR is responsible for determining closure once the criteria
+  are met.
 - If auto-closing is disabled or the PR targets a non-default branch, close
-  the issue manually after merge.
+  the issue manually after merge only when acceptance criteria are satisfied.
 - A closed issue must reflect completed work. If work is deferred, keep the
   issue open or create a follow-up issue and link it explicitly.
 

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -33,12 +33,12 @@ PR description and list the files changed.
 Every pull request must have a primary GitHub issue. If no issue exists,
 create one before creating a branch or changing files.
 
-When a pull request resolves a tracked issue, include a closing keyword in the
-PR description so the issue auto-closes on merge (for example, `Fixes #123`).
-If auto-close is not possible, the PR must still reference the issue and the
-issue must be closed manually after merge. Work is not complete until the
-issue is closed. See [GitHub Issue Standards](github-issues.md) for rules on
-non-closing PRs and sub-issues.
+If the issue has no special acceptance criteria, include a closing keyword in
+the PR description so the issue auto-closes on merge (for example, `Fixes
+#123`). If acceptance criteria exist, use a non-closing reference and close
+the issue only after the criteria are satisfied. See
+[GitHub Issue Standards](github-issues.md) for acceptance criteria rules and
+sub-issue guidance.
 
 ## Pull request template
 Every repository must install a pull request template at
@@ -53,7 +53,8 @@ Minimum required template:
 - 
 
 ## Issue Linkage
-- Fixes #
+- Fixes # (default; use when no acceptance criteria exist)
+- Ref # (use when acceptance criteria exist)
 - Work is not complete until the issue is closed.
 - If no issue exists, open one before any work begins.
 


### PR DESCRIPTION
## Summary
- Require acceptance criteria when not obvious and define auto-close behavior.
- Update PR issue linkage guidance to respect acceptance criteria.

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/code-management/github-issues.md
  - docs/code-management/pull-request-workflow.md
