### PR TITLE
docs: add automation repo type and update library branching

### DIFF
--- a/docs/code-management/automation-branching-model.md
+++ b/docs/code-management/automation-branching-model.md
@@ -1,0 +1,110 @@
+# Automation Branching Model
+
+## Table of Contents
+- [Status](#status)
+- [1. Purpose](#1-purpose)
+- [2. Scope](#2-scope)
+- [3. Core invariants](#3-core-invariants)
+- [4. Branch roles](#4-branch-roles)
+  - [develop](#develop)
+  - [main](#main)
+  - [release branches](#release-branches)
+- [5. Short-lived branches](#5-short-lived-branches)
+  - [feature/*](#feature)
+  - [bugfix/*](#bugfix)
+  - [hotfix/*](#hotfix)
+- [6. Release workflow](#6-release-workflow)
+- [7. Forbidden operations](#7-forbidden-operations)
+- [8. Related documents](#8-related-documents)
+
+## Status
+Active v0.2
+
+---
+
+## 1. Purpose
+Define a branching model for tooling and automation repositories that preserves
+stable releases while keeping development flow simple.
+
+## 2. Scope
+Applies to automation repositories, including shared GitHub Actions, scripts,
+and tooling libraries that are consumed across repositories.
+
+## 3. Core invariants
+- `develop` is the integration branch for all changes.
+- `main` represents stable, released automation.
+- Releases are tagged and immutable.
+- Release branches exist only when multiple versions must be supported.
+
+## 4. Branch roles
+
+### develop
+- default branch for active development
+- entry point for all code changes
+
+### main
+- stable release branch
+- merges only from `develop` or release branches
+- source of tagged releases
+
+### release branches
+Long-lived branches for supported release lines when needed.
+
+Naming:
+- `release/<major>.<minor>.x`
+
+Rules:
+- patch-only changes
+- no new features
+- no merges from `develop` or `main`
+
+## 5. Short-lived branches
+All work occurs in short-lived branches that merge into `develop` or a release
+branch.
+
+### feature/*
+Use for:
+- new automation capabilities
+- refactors or structural changes
+- documentation updates
+
+Rules:
+- branched from `develop`
+- merged into `develop`
+- deleted after merge
+
+### bugfix/*
+Use for:
+- non-urgent defect fixes
+- patch changes on a release branch
+
+Rules:
+- branched from `develop` or the target release branch
+- merged into the branch it was created from
+- deleted after merge
+
+### hotfix/*
+Use for:
+- urgent defects affecting released automation
+
+Rules:
+- branched from the affected release branch or `main`
+- merged into that branch
+- backported to `develop`
+- deleted after merge
+
+## 6. Release workflow
+- Merge `develop` into `main` for stable releases.
+- Tag releases on `main`.
+- For patch releases on older lines, release from the relevant release branch
+  and merge back to `main`.
+
+## 7. Forbidden operations
+- direct commits to `develop`, `main`, or release branches
+- merging `develop` into release branches
+- releasing from untagged or dirty source
+
+## 8. Related documents
+- Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
+- Shared actions library: [shared-actions-library.md](shared-actions-library.md)
+- Release and versioning policy: [release-versioning.md](release-versioning.md)

--- a/docs/code-management/branching-and-deployment.md
+++ b/docs/code-management/branching-and-deployment.md
@@ -46,6 +46,10 @@ Documentation repositories follow the documentation branching model and are not
 governed by this document. See
 [documentation-branching-model.md](documentation-branching-model.md).
 
+Automation repositories follow the automation branching model and are not
+governed by this document. See
+[automation-branching-model.md](automation-branching-model.md).
+
 Repository type definitions live in
 [repository-types-and-attributes.md](repository-types-and-attributes.md).
 

--- a/docs/code-management/documentation-branching-model.md
+++ b/docs/code-management/documentation-branching-model.md
@@ -38,6 +38,7 @@ snippets only and do not publish deployable artifacts.
 ### main
 - default branch for documentation
 - source of published GitHub content
+- integration and release branch when a single branch is used
 
 ## 5. Short-lived branches
 Use short-lived branches for all changes.

--- a/docs/code-management/library-branching-and-release.md
+++ b/docs/code-management/library-branching-and-release.md
@@ -6,6 +6,7 @@
 - [2. Scope](#2-scope)
 - [3. Core invariants](#3-core-invariants)
 - [4. Branch roles](#4-branch-roles)
+  - [develop](#develop)
   - [main](#main)
   - [release branches](#release-branches)
 - [5. Short-lived branches](#5-short-lived-branches)
@@ -32,17 +33,22 @@ Applies to library repositories that publish artifacts to a package registry and
 are not deployed to environment-bound infrastructure.
 
 ## 3. Core invariants
-- `main` is the integration branch.
+- `develop` is the integration branch.
+- `main` represents the current stable release line.
 - Stable releases are tagged and published from `main` or a release branch.
 - Release branches represent supported `MAJOR.MINOR` release lines.
-- Changes land in `main` first; backports are explicit.
+- Changes land in `develop` first; promotions and backports are explicit.
 - Released artifacts are immutable and reproducible from source.
 
 ## 4. Branch roles
 
-### main
+### develop
 - default branch for active development
-- source of new `MAJOR` and `MINOR` releases
+- entry point for all code changes
+
+### main
+- stable release branch for the latest line
+- source of tagged releases
 
 ### release branches
 Long-lived branches for supported release lines.
@@ -53,14 +59,14 @@ Naming:
 Rules:
 - patch-only changes
 - no new features
-- no merges from `main`
+- no merges from `develop` or `main`
 
 Support policy:
 - default target is the current and previous `MAJOR.MINOR` lines
 - repositories may expand or contract support by updating the repository profile
 
 ## 5. Short-lived branches
-All work occurs in short-lived branches that merge into `main` or a release
+All work occurs in short-lived branches that merge into `develop` or a release
 branch.
 
 ### feature/*
@@ -70,8 +76,8 @@ Use for:
 - documentation updates
 
 Rules:
-- branched from `main`
-- merged into `main`
+- branched from `develop`
+- merged into `develop`
 - deleted after merge
 
 ### bugfix/*
@@ -80,7 +86,7 @@ Use for:
 - patch releases on a release branch
 
 Rules:
-- branched from `main` or the target release branch
+- branched from `develop` or the target release branch
 - merged into the branch it was created from
 - deleted after merge
 
@@ -91,11 +97,13 @@ Use for:
 Rules:
 - branched from the affected release branch
 - merged into that release branch
-- backported to `main`
+- backported to `develop`
+- merged into `main` when the fix applies to the latest line
 - deleted after merge
 
 ## 6. Release workflow
-- `MAJOR` and `MINOR` releases are cut from `main`.
+- `MAJOR` and `MINOR` releases are promoted from `develop` to `main`.
+- Tag releases on `main` after the promotion merge.
 - `PATCH` releases are cut from the relevant release branch.
 - Every release is tagged and published as an immutable artifact.
 
@@ -112,7 +120,8 @@ Rules:
 
 ## 9. Forbidden operations
 - direct commits to `main` or release branches
-- merging `main` into release branches
+- direct commits to `develop`
+- merging `develop` into release branches
 - releasing from untagged or dirty source
 - publishing artifacts without a matching source tag
 

--- a/docs/code-management/overview.md
+++ b/docs/code-management/overview.md
@@ -19,6 +19,7 @@ tool-specific requirements belong in development standards.
 - Branching and deployment: [branching-and-deployment.md](branching-and-deployment.md)
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Documentation branching model: [documentation-branching-model.md](documentation-branching-model.md)
+- Automation branching model: [automation-branching-model.md](automation-branching-model.md)
 - Shared actions library: [shared-actions-library.md](shared-actions-library.md)
 - Hotfix policy: [hotfix-policy.md](hotfix-policy.md)
 - Release and versioning: [release-versioning.md](release-versioning.md)

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -7,6 +7,7 @@
   - [Application repositories](#application-repositories)
   - [Library repositories](#library-repositories)
   - [Documentation repositories](#documentation-repositories)
+  - [Automation repositories](#automation-repositories)
 - [3. Versioning](#3-versioning)
 - [4. Pre-release policy](#4-pre-release-policy)
 - [5. Artifact Properties](#5-artifact-properties)
@@ -53,6 +54,11 @@ For library repositories, a release is tied to publishing:
 Documentation repositories do not require formal releases or version numbers.
 Git history and tags (when needed) are the source of truth.
 
+### Automation repositories
+Automation repositories release by tagging a versioned automation artifact. If
+the automation is published (for example, via GitHub Actions), the tag is the
+source of truth.
+
 ---
 
 ## 3. Versioning
@@ -86,6 +92,7 @@ Artifacts are first-class operational objects.
 ## 6. Relationship to Branches
 - Application branches drive deployment automation.
 - Library releases are cut from `main` or release branches.
+- Automation releases are cut from `main` or release branches.
 - Artifacts provide audit, rollback, and traceability.
 
 Operational truth is anchored in artifacts, not branch pointers.

--- a/docs/code-management/repository-types-and-attributes.md
+++ b/docs/code-management/repository-types-and-attributes.md
@@ -8,6 +8,7 @@
   - [Application repositories](#application-repositories)
   - [Library repositories](#library-repositories)
   - [Documentation repositories](#documentation-repositories)
+  - [Automation repositories](#automation-repositories)
 - [Required repository attributes](#required-repository-attributes)
 - [Declaration requirement](#declaration-requirement)
 - [Change control](#change-control)
@@ -57,14 +58,26 @@ A documentation repository:
 Use:
 - Documentation branching model: [documentation-branching-model.md](documentation-branching-model.md)
 
+### Automation repositories
+An automation repository:
+- provides tooling or automation shared across repositories
+- may be consumed as a dependency or referenced by workflows
+- is released as tagged, versioned automation
+ - uses repository-level SemVer tags
+
+Use:
+- Automation branching model: [automation-branching-model.md](automation-branching-model.md)
+- Shared actions library: [shared-actions-library.md](shared-actions-library.md)
+
 ## Required repository attributes
 Each repository must declare, at minimum:
-- `repository_type`: `application`, `library`, or `documentation`
-- `versioning_scheme`: application or library scheme (or ecosystem-specific override), or `none`
-- `branching_model`: application promotion model, library release model, or documentation single-branch model
-- `release_model`: environment promotion, package publishing, or `none`
+- `repository_type`: `application`, `library`, `documentation`, or `automation`
+- `versioning_scheme`: `application`, `library`, `ecosystem-specific`, or `none`
+- `branching_model`: `application-promotion`, `library-release`, `docs-single-branch`, or `automation-develop-main`
+- `release_model`: `environment-promotion`, `package-publishing`, `tagged-automation`, or `none`
 - `supported_release_lines`: a single active line for applications; one or more
-  `MAJOR.MINOR` lines for libraries; `none` for documentation
+  `MAJOR.MINOR` lines for libraries; `none` for documentation; one or more
+  `MAJOR` lines for automation
 
 ## Declaration requirement
 Record repository type and attributes in the repository's
@@ -79,6 +92,7 @@ references.
 - Branching and deployment model: [branching-and-deployment.md](branching-and-deployment.md)
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Documentation branching model: [documentation-branching-model.md](documentation-branching-model.md)
+- Automation branching model: [automation-branching-model.md](automation-branching-model.md)
 - Release and versioning policy: [release-versioning.md](release-versioning.md)
 - Application versioning scheme: [application-versioning-scheme.md](application-versioning-scheme.md)
 - Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)

--- a/docs/code-management/shared-actions-library.md
+++ b/docs/code-management/shared-actions-library.md
@@ -4,6 +4,7 @@
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Design principles](#design-principles)
+- [Branching model](#branching-model)
 - [Repository structure](#repository-structure)
 - [Action design rules](#action-design-rules)
 - [Versioning and pinning](#versioning-and-pinning)
@@ -26,6 +27,12 @@ release, or pull request workflows.
 - Prefer composite actions over per-repository scripts.
 - Version everything; never consume unpinned defaults.
 - Build actions that are usable across application and library repositories.
+
+## Branching model
+- Default branch is `develop` and is the integration branch.
+- `main` represents the stable release line.
+- Release branches are optional and use `release/<major>.<minor>.x` when needed.
+- All releases are tagged on `main` or a release branch.
 
 ## Repository structure
 A shared actions repository must be organized by responsibility:
@@ -50,7 +57,8 @@ Rules:
 - Avoid tightly coupling actions to a single repository structure.
 
 ## Versioning and pinning
-- Tag stable release lines (for example, `v1`, `v1.2.0`).
+- Version the repository with SemVer tags (for example, `v1`, `v1.2.0`).
+- Tags apply to the entire repository; there is no per-action tagging.
 - Repositories must reference actions by tag or commit SHA.
 - Never reference the default branch.
 
@@ -67,7 +75,7 @@ Rules:
 
 ## Implementation plan
 Phase 0: decisions
-- Choose repository name, visibility, and default branch.
+- Choose repository name, visibility, and default branch (`develop`).
 - Select the initial versioning/tagging policy.
 
 Phase 1: bootstrap
@@ -96,5 +104,6 @@ Phase 6: rollout
 - Keep changes small and reversible.
 
 ## Related documents
+- Automation branching model: [automation-branching-model.md](automation-branching-model.md)
 - Source control guidelines: [source-control-guidelines.md](source-control-guidelines.md)
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -41,11 +41,11 @@ rules unless a deviation exists.
   - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
   - Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
 - Repository profile:
-  - repository_type: <application|library|documentation>
+  - repository_type: <application|library|documentation|automation>
   - versioning_scheme: <application|library|ecosystem-specific|none>
-  - branching_model: <application-promotion|library-release|docs-single-branch>
-  - release_model: <environment-promotion|package-publishing|none>
-  - supported_release_lines: <single|list of MAJOR.MINOR lines|none>
+  - branching_model: <application-promotion|library-release|docs-single-branch|automation-develop-main>
+  - release_model: <environment-promotion|package-publishing|tagged-automation|none>
+  - supported_release_lines: <single|list of MAJOR.MINOR lines|MAJOR lines|none>
 
 ## Template
 ```
@@ -65,11 +65,11 @@ https://github.com/<org>/<standards-repo>
 - AI co-authors:
   - Co-Authored-By: ai-tool <id+ai-tool@users.noreply.github.com>
 - Repository profile:
-  - repository_type: <application|library|documentation>
+  - repository_type: <application|library|documentation|automation>
   - versioning_scheme: <application|library|ecosystem-specific|none>
-  - branching_model: <application-promotion|library-release|docs-single-branch>
-  - release_model: <environment-promotion|package-publishing|none>
-  - supported_release_lines: <single|list of MAJOR.MINOR lines|none>
+  - branching_model: <application-promotion|library-release|docs-single-branch|automation-develop-main>
+  - release_model: <environment-promotion|package-publishing|tagged-automation|none>
+  - supported_release_lines: <single|list of MAJOR.MINOR lines|MAJOR lines|none>
 - Local deviations:
   - <explicit deviation, if any>
 ```


### PR DESCRIPTION
# Pull Request

## Summary
- align library branching with develop/main semantics
- add automation repo type and branching model
- update shared actions standard for repo-level SemVer and develop/main branching

## Issue Linkage
- Fixes #44
- Work is not complete until the issue is closed.

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/code-management/automation-branching-model.md
  - docs/code-management/branching-and-deployment.md
  - docs/code-management/documentation-branching-model.md
  - docs/code-management/library-branching-and-release.md
  - docs/code-management/overview.md
  - docs/code-management/release-versioning.md
  - docs/code-management/repository-types-and-attributes.md
  - docs/code-management/shared-actions-library.md
  - docs/standards-and-conventions.md

## Notes
- None.
