### PR TITLE
docs: define docs-only CI gating

### DIFF
--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -33,6 +33,10 @@ PR description and list the files changed.
 Documentation repositories may define "docs-only" as the entire repository and
 keep validation optional unless the repository documents a required check.
 
+CI workflows must implement the docs-only skip policy in
+[source-control-guidelines.md](source-control-guidelines.md#docs-only-ci-skip-policy).
+If a docs-only validation command exists, run it even when tests are skipped.
+
 ## Issue linkage
 Every pull request must have a primary GitHub issue. If no issue exists,
 create one before creating a branch or changing files.

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -15,13 +15,14 @@
   - [Deployment Rule](#deployment-rule)
 - [5. CI/CD Constraints](#5-cicd-constraints)
   - [CI gates](#ci-gates)
+  - [Docs-only CI skip policy](#docs-only-ci-skip-policy)
 - [6. Locked vs. Flexible Decisions](#6-locked-vs-flexible-decisions)
   - [Locked at v0.1](#locked-at-v01)
   - [Explicitly Flexible](#explicitly-flexible)
 - [7. Guiding Principle](#7-guiding-principle)
 
 ## Status
-Frozen v0.1 snapshot
+Active v0.2
 
 ---
 
@@ -143,6 +144,20 @@ so failing GitHub Actions block PR merges.
 
 Each repository must also document which hard gates apply per branch. Some
 hard gates may be develop-only, while others must run on all eternal branches.
+
+### Docs-only CI skip policy
+Repositories must define a docs-only allowlist (for example, `docs/**`,
+`README.md`, and `CHANGELOG.md`). `.github/**` is not docs-only.
+
+CI workflows must include a docs-only detection job that computes
+`docs_only=true|false` based on the PR diff against the allowlist and exposes it
+as a workflow output.
+
+When `docs_only` is `true`, skip test and version-validation jobs by gating
+them with the docs-only output. Dependency audits should still run by default;
+if a repository chooses to skip them, it must document the exception.
+
+Docs-only validation commands, when defined, must still run.
 
 ---
 

--- a/docs/development/python/local-validation-scripts.md
+++ b/docs/development/python/local-validation-scripts.md
@@ -1,0 +1,49 @@
+# Local validation scripts
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Requirements](#requirements)
+- [CI parity](#ci-parity)
+- [Version validation](#version-validation)
+- [Failure behavior and output](#failure-behavior-and-output)
+
+## Purpose
+Define the required behavior for repository-local validation scripts (for
+example, `scripts/dev/validate_local.py`) so local checks reliably match CI
+hard gates.
+
+## Scope
+Applies to Python repositories that define a canonical local validation
+command. Repositories that do not define such a command must document their
+alternative process in the pull request workflow.
+
+## Requirements
+- Provide a canonical local validation command at `scripts/dev/validate_local.py`.
+- Run from the repository root and fail fast if executed elsewhere.
+- Invoke Python as `python3` and use the project environment.
+- Execute all CI hard-gate checks locally with the same tools and flags.
+- Permit additional local-only checks when documented, but never omit CI hard
+  gates.
+- Avoid side effects beyond validation (no automatic fixes or rewrites).
+- Return a non-zero exit code on failure.
+
+## CI parity
+The local validation script must mirror CI hard gates, including:
+- dependency and lockfile validation
+- linting and type checking
+- tests with the same marker selection and coverage thresholds
+- security or dependency audits required by CI
+
+If CI separates unit and integration jobs, the local script must run both sets
+of tests to keep coverage and integration behavior aligned.
+
+## Version validation
+If CI enforces version comparison against a base branch, the local script must
+support passing a base reference (for example, `--base-ref develop`) and must
+document the default behavior (for example, resolving `origin/HEAD`).
+
+## Failure behavior and output
+- Print the command being executed before each step.
+- Stop at the first failing command and return that exit code.
+- Surface missing prerequisites with actionable error messages.

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -47,10 +47,14 @@ Branch applicability:
 - release: all hard gates required
 - main: all hard gates required
 
+Docs-only pull requests may skip these jobs when the repository implements the
+docs-only CI skip policy.
+
 ## Document Map
 - Naming conventions: [naming-conventions.md](naming-conventions.md)
 - Import-time side effects: [import-time-side-effects.md](import-time-side-effects.md)
 - Type hints: [type-hints.md](type-hints.md)
 - Testing and coverage: [testing-and-coverage.md](testing-and-coverage.md)
 - Dependency management: [dependency-management.md](dependency-management.md)
+- Local validation scripts: [local-validation-scripts.md](local-validation-scripts.md)
 - Python version management: [version-management.md](version-management.md)


### PR DESCRIPTION
# Pull Request

## Summary
- add docs-only CI skip policy to CI gate standards
- document local validation script requirements for Python repos
- note docs-only gating in Python CI gates

## Issue Linkage
- Fixes #48
- Work is not complete until the issue is closed.

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/code-management/source-control-guidelines.md
  - docs/code-management/pull-request-workflow.md
  - docs/development/python/overview.md
  - docs/development/python/local-validation-scripts.md

## Notes
- None.
