### PR TITLE
docs: derive build numbers for applications

### DIFF
--- a/docs/code-management/application-versioning-scheme.md
+++ b/docs/code-management/application-versioning-scheme.md
@@ -8,6 +8,7 @@
 - [Version format](#version-format)
 - [Source of truth](#source-of-truth)
 - [Increment rules](#increment-rules)
+- [Build derivation](#build-derivation)
 - [Promotion workflow](#promotion-workflow)
 - [Validation and failure modes](#validation-and-failure-modes)
 - [Related documents](#related-documents)
@@ -30,11 +31,14 @@ models.
 
 ## Invariants
 - Every deployed artifact maps to a unique version string.
-- The rightmost component increments on every merge to the develop branch.
-- `PATCH` increments when a promotion to the release branch is opened.
+- The base version (`MAJOR.MINOR.PATCH`) is stored in a manifest and changes
+  only via pull request.
+- `BUILD` is derived at build time; build numbers are never committed to git.
+- `PATCH` increments when a promotion to the release branch is opened to start
+  a new development cycle.
 - `MAJOR` and `MINOR` changes are explicit human decisions.
 - Version numbers are never reused or mutated after deployment.
-- The scheme avoids implicit state and hidden counters.
+- The scheme avoids implicit state and hidden counters in source control.
 
 ## Version format
 Use a four-part numeric version string:
@@ -45,23 +49,44 @@ MAJOR.MINOR.PATCH.BUILD
 
 Rules:
 - Each component is a non-negative integer with no leading zeros (except `0`).
-- `BUILD` is the rightmost component and auto-increments.
+- `BUILD` is the rightmost component and is computed at build time.
 - No suffixes or build metadata are used in the version string.
 
 ## Source of truth
-- The canonical version string lives in a single build or package manifest.
-- All other references must derive from that value; do not duplicate it in code.
-- Runtime reads should use package metadata rather than hard-coded strings.
+- The canonical base version (`MAJOR.MINOR.PATCH`) lives in a single build or
+  package manifest.
+- The full runtime version string (`MAJOR.MINOR.PATCH.BUILD`) is derived at
+  build time.
+- All other references must derive from the base version or computed runtime
+  version; do not duplicate it in code.
 
 ## Increment rules
-- `BUILD` increments by exactly 1 on every merge to the develop branch.
 - `PATCH` increments by exactly 1 when a promotion to the release branch opens
-  and resets `BUILD` to `0`.
-- `MAJOR` and `MINOR` changes reset `PATCH` and `BUILD` to `0`.
+  and starts a new development cycle.
+- `MAJOR` and `MINOR` changes reset `PATCH` to `0` and restart the build
+  sequence through derivation.
 - Version changes are part of merge pull requests; direct commits to develop
   or release branches are forbidden.
-- If the develop branch advances before merge, rebase and reapply the next
-  `BUILD` value to avoid collisions.
+- Feature and bugfix pull requests do not change the base version unless they
+  are explicitly designated as version-bump work.
+
+## Build derivation
+`BUILD` is derived from git history and does not live in source control.
+
+Recommended algorithm:
+1. Read the base version from the manifest (`MAJOR.MINOR.PATCH`).
+2. Find the commit that introduced that base version.
+3. Set `BUILD` to the number of commits since that commit on the current
+   branch.
+
+Release tagging:
+- Tag release bases as `vMAJOR.MINOR.PATCH` when promoting to the release
+  branch.
+- CI pipelines should fetch full history (`fetch-depth: 0`) so the build
+  derivation is deterministic.
+
+If the base version commit cannot be found (for example, shallow history),
+fail the build rather than guessing.
 
 ## Promotion workflow
 1. Create a promotion branch from develop and open a pull request to the
@@ -69,17 +94,16 @@ Rules:
 2. If the release branch has diverged, merge release into the promotion branch
    and resolve conflicts there.
 3. Immediately open a separate pull request back to develop that increments
-   `PATCH` and resets `BUILD` to `0`.
+   `PATCH` to start the next development cycle.
 4. Merge the promotion pull request only after release validation.
 5. Merge the `PATCH` bump pull request before the next develop merge.
 6. Promote release to production with no additional version changes.
 
 ## Validation and failure modes
 CI must fail when:
-- The version string does not match `MAJOR.MINOR.PATCH.BUILD`.
-- `BUILD` is not exactly one higher than the current develop value for
-  merge pull requests.
-- `PATCH` bump pull requests do not reset `BUILD` to `0`.
+- The base version string does not match `MAJOR.MINOR.PATCH`.
+- The derived build number cannot be computed deterministically.
+- `PATCH` bump pull requests do not increment `PATCH` by exactly 1.
 - A version number is reused or regresses.
 
 Violations are fatal exceptions that block merges, releases, and deployments.

--- a/docs/code-management/library-versioning-scheme.md
+++ b/docs/code-management/library-versioning-scheme.md
@@ -46,6 +46,8 @@ Rules:
 - The canonical version string lives in a single build or package manifest.
 - All other references must derive from that value; do not duplicate it in code.
 - Runtime reads should use package metadata rather than hard-coded strings.
+- For Python packages, the manifest is `pyproject.toml`; avoid local version
+  segments or build metadata unless the ecosystem requires them.
 
 ## Increment rules
 - `MAJOR` increments for breaking API or behavioral changes.

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -43,12 +43,16 @@ Releases are not mutable.
 For application repositories, a release is tied to promotion:
 - merge into the `release` or `main` branch
 - produce a versioned artifact for deployment
+- tag the release base as `vMAJOR.MINOR.PATCH`
 
 ### Library repositories
 For library repositories, a release is tied to publishing:
 - tag a version in source control
 - publish the artifact to the package registry when applicable
 - tagging alone is sufficient when distribution is via source control
+
+For ecosystems with strict versioning (for example, PyPI), use the ecosystem
+format (PEP 440) and never attempt to republish the same version.
 
 ### Documentation repositories
 Documentation repositories do not require formal releases or version numbers.
@@ -58,13 +62,15 @@ Git history and tags (when needed) are the source of truth.
 
 ## 3. Versioning
 - Use the applicable versioning scheme for the artifact type.
-- Version numbers are assigned at release time.
+- Base versions are assigned explicitly; build numbers are derived at build time
+  for applications.
 - Version bumps are explicit and reviewed.
 
 Guideline:
 - Libraries: use the Library Versioning Scheme or the ecosystem's required
   versioning format.
-- Applications: use the Application Versioning Scheme (`MAJOR.MINOR.PATCH.BUILD`).
+- Applications: use the Application Versioning Scheme
+  (`MAJOR.MINOR.PATCH.BUILD`) with a derived `BUILD` value.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary
- Define derived BUILD numbers for application versioning.
- Clarify library/PyPI versioning expectations.

## Issue Linkage
- Fixes #52

## Testing
- Docs-only: tests skipped.

## Notes
- None.
