### PR TITLE
docs: add ty to python standards

### DIFF
--- a/docs/development/python/local-validation-scripts.md
+++ b/docs/development/python/local-validation-scripts.md
@@ -31,7 +31,7 @@ alternative process in the pull request workflow.
 ## CI parity
 The local validation script must mirror CI hard gates, including:
 - dependency and lockfile validation
-- linting and type checking
+- linting and type checking (run all required checkers, including mypy and ty)
 - tests with the same marker selection and coverage thresholds
 - security or dependency audits required by CI
 

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -18,7 +18,8 @@ and long-term survivability across repositories.
 
 ## Tooling Expectations
 - Default linting: ruff.
-- Default type checking: mypy in strict mode.
+- Default type checking: mypy in strict mode and ty with default settings.
+- Mypy remains authoritative until ty cutover is explicitly approved.
 - If a repository uses different tools, document the reason and equivalents.
 - Invoke Python as `python3` and use a project-specific environment for all
   Python commands. See `docs/development/environment-and-tooling.md`.
@@ -58,3 +59,4 @@ docs-only CI skip policy.
 - Dependency management: [dependency-management.md](dependency-management.md)
 - Local validation scripts: [local-validation-scripts.md](local-validation-scripts.md)
 - Python version management: [version-management.md](version-management.md)
+- Ty migration plan: [ty-migration-plan.md](ty-migration-plan.md)

--- a/docs/development/python/ty-migration-plan.md
+++ b/docs/development/python/ty-migration-plan.md
@@ -41,7 +41,7 @@ enough to build confidence, and then retire `mypy` once parity is proven.
 
 ### Phase 0: Baseline decisions
 1. Pin `ty` to the latest available version at adoption time (current target:
-   `0.0.11` from the 2026-01-07 release) and manage it like other dev tools.
+   `0.0.13`, released 2026-01-21) and manage it like other dev tools.
 2. Use community defaults: `ty check` as the canonical command and
    `[tool.ty]` in `pyproject.toml` for configuration.
 3. Define the parity criteria required to remove `mypy` (TBD; data-driven).

--- a/docs/development/python/type-hints.md
+++ b/docs/development/python/type-hints.md
@@ -7,7 +7,7 @@
 
 ## Rule
 All public functions and methods must have complete type hints. Enforce this
-with a static type checker in strict mode.
+with static type checkers: mypy in strict mode and ty with default settings.
 
 ## Rationale
 Type hints are documentation, enable static analysis, and catch bugs during


### PR DESCRIPTION
# Pull Request

## Summary
- update python standards to run ty alongside mypy
- refresh ty migration plan with current pinned version

## Issue Linkage
- Ref #60

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/development/python/overview.md
  - docs/development/python/type-hints.md
  - docs/development/python/local-validation-scripts.md
  - docs/development/python/ty-migration-plan.md

## Notes
- 
