### PR TITLE
docs: add type checker parity protocol

### DIFF
--- a/docs/development/python/type-hints.md
+++ b/docs/development/python/type-hints.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Rule](#rule)
 - [Rationale](#rationale)
+- [Type checker parity protocol](#type-checker-parity-protocol)
 - [Examples](#examples)
 
 ## Rule
@@ -12,6 +13,24 @@ with static type checkers: mypy in strict mode and ty with default settings.
 ## Rationale
 Type hints are documentation, enable static analysis, and catch bugs during
 development.
+
+## Type checker parity protocol
+Both `mypy` and `ty` are hard CI gates. Failing either one blocks the pull
+request.
+
+When the tools disagree, follow this protocol:
+1. Run both checkers locally with the canonical commands and capture the exact
+   outputs.
+2. Confirm configuration parity (strictness, ignores, per-module overrides,
+   file selection) across `mypy` and `ty`.
+3. If the failure is `mypy`-only, treat it as a blocker and resolve it. If the
+   `mypy` error is intentionally suppressed, mirror the suppression or
+   document the rationale for `ty`.
+4. If the failure is `ty`-only, treat it as a blocker and resolve it. If `ty`
+   is flagging a real issue, fix the code; if it is a false positive, document
+   the discrepancy and adjust configuration where possible.
+5. Record the mismatch in a GitHub issue with the outputs from both tools and
+   the resolution path.
 
 ## Examples
 ```python


### PR DESCRIPTION
# Pull Request

## Summary
- add a protocol for mypy vs ty mismatch triage

## Issue Linkage
- Ref #60

## Testing
- Docs-only: tests skipped
- Files changed:
  - docs/development/python/type-hints.md

## Notes
- 
