### PR TITLE
docs: define python minor upgrade policy

### DIFF
--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -36,7 +36,7 @@ Soft gate definition:
   surfaced with rationale and follow-up tracking when applicable.
 
 Hard gates (all are required status checks):
-- `test-and-validate (3.14)`
+- `test-and-validate (current)`
 - `integration-tests`
 - `dependency-audit`
 
@@ -50,6 +50,9 @@ Branch applicability:
 
 Docs-only pull requests may skip these jobs when the repository implements the
 docs-only CI skip policy.
+
+When dual-minor testing is active, the next-minor job is advisory and must not
+be configured as a required status check. Only the current minor blocks merges.
 
 ## Document Map
 - Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/docs/development/python/version-management.md
+++ b/docs/development/python/version-management.md
@@ -8,6 +8,9 @@
 - [Upgrade workflow](#upgrade-workflow)
   - [Patch-level](#patch-level)
   - [Minor- or major-level](#minor--or-major-level)
+  - [Minor release preview (dual-CI)](#minor-release-preview-dual-ci)
+  - [Cutover criteria](#cutover-criteria)
+  - [Stability tracking](#stability-tracking)
 - [Host decoupling and parity](#host-decoupling-and-parity)
   - [Parity requirements](#parity-requirements)
   - [Decoupling strategies](#decoupling-strategies)
@@ -56,6 +59,38 @@ When incrementing the application `MINOR` or `MAJOR` version:
    beneficial for the next cycle.
 3. If a runtime upgrade is attempted, test each candidate version individually
    before combining with other changes.
+
+### Minor release preview (dual-CI)
+When the next Python minor series transitions from pre-release to bugfix
+(stable) status:
+1. At the start of the next development cycle, add the next minor version to
+   the CI matrix.
+2. Keep the current minor version as the only hard gate. The next minor check
+   is advisory and must not block merges.
+3. Record any failures in the next minor check and track them as issues, but
+   do not block PRs unless the current minor fails.
+
+### Cutover criteria
+Promote the next minor version to current only after it has been stable in CI
+for at least two full development cycles.
+
+At the start of the next development cycle after meeting the stability
+threshold:
+1. Update the canonical Python version to the new minor series.
+2. Make the new minor the required (hard-gate) CI runtime.
+3. Remove the prior minor from required CI or demote it to advisory if needed.
+
+### Stability tracking
+Once dual-CI begins, record stability status at the start of each development
+cycle. Capture:
+- cycle start date
+- current minor version
+- candidate minor version
+- CI status summary and any open issues blocking promotion
+
+Store the stability log in a repository-local doc (for example,
+`docs/development/python/version-stability-log.md`) and keep it updated until
+the cutover is complete.
 
 ## Host decoupling and parity
 


### PR DESCRIPTION
# Pull Request

## Summary
- Document dual-CI preview, cutover criteria, and stability tracking for new Python minor releases.
- Update CI gate wording to reflect advisory next-minor checks.

## Issue Linkage
- Fixes #69

## Testing
- Docs-only: tests skipped.

## Notes
- Docs-only: tests skipped.
- Files changed:
  - docs/development/python/version-management.md
  - docs/development/python/overview.md
