### PR TITLE
Docs: add skills library guidance

### DIFF
--- a/docs/foundation/agent-skills.md
+++ b/docs/foundation/agent-skills.md
@@ -1,0 +1,35 @@
+# Agent skills
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Repository-local skills](#repository-local-skills)
+- [Shared skills library](#shared-skills-library)
+- [Registration and loading](#registration-and-loading)
+
+## Purpose
+Define how skills are stored, imported, and referenced so repositories avoid
+external runtime dependencies while still benefiting from shared workflows.
+
+## Scope
+Applies to any repository that uses skills to guide agent behavior or
+automation.
+
+## Repository-local skills
+- Store repo-specific skills under `skills/` at the repository root.
+- Treat `skills/` as the source of truth for skill content used in that repo.
+- If a skill is required for repo workflows, document it in `AGENTS.md`.
+
+## Shared skills library
+- The `standards-and-conventions` repository hosts shared skills under
+  `skills/` as a reference library.
+- To avoid external dependencies, copy shared skills into the target
+  repository’s `skills/` directory before use.
+- Do not rely on symlinks or external paths for required skills.
+
+## Registration and loading
+- Skills are not auto-registered by documentation alone.
+- If a skill does not appear in the active skill list, restart the agent
+  session after adding it.
+- Repositories should assume that skill availability may require a session
+  reload and document that expectation in `AGENTS.md`.

--- a/docs/repository/repository-structure.md
+++ b/docs/repository/repository-structure.md
@@ -27,6 +27,7 @@ Use the following directories by default:
 - `src/`: production source code (when applicable)
 - `tests/`: tests that mirror the source layout
 - `scripts/`: developer tooling and automation
+- `skills/`: repository-local agent skills (when applicable)
 - `.github/`: CI/CD workflows and repository configuration
 
 Additional directories (for example, `infra/` or `deploy/`) are allowed when
@@ -61,6 +62,7 @@ repo/
 ├── tests/
 │   └── <package_or_app>/
 ├── scripts/
+├── skills/
 ├── .github/
 │   └── workflows/
 └── README.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,50 +1,13 @@
-# Skills overview
+# Skills library
 
 ## Table of Contents
 - [Purpose](#purpose)
-- [Scope](#scope)
-- [Skill list](#skill-list)
-- [Usage conventions](#usage-conventions)
-- [Downstream references](#downstream-references)
+- [Usage](#usage)
 
 ## Purpose
-Provide a canonical, repository-managed set of Codex skills derived from the
-standards in this repository.
+Provide shared skills that repositories can copy into their own `skills/`
+directories when needed.
 
-## Scope
-These skills are shared across repositories that adopt the standards here.
-Skill bodies must remain aligned with the canonical documents they reference.
-
-## Skill list
-- `summarize` (`skills/summarize/SKILL.md`): multi-mode summarization for
-  decisions, operations, and SOC capture.
-- `summarize-decisions` (`skills/summarize-decisions/SKILL.md`): wrapper for
-  decisions summaries (autocomplete-friendly).
-- `summarize-operations` (`skills/summarize-operations/SKILL.md`): wrapper for
-  operations summaries (autocomplete-friendly).
-- `summarize-soc` (`skills/summarize-soc/SKILL.md`): wrapper for SOC capture
-  summaries (autocomplete-friendly).
-- `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow with
-  docs-only exception handling.
-- `dependency-update` (`skills/dependency-update/SKILL.md`): dependency update
-  workflow with failure handling and anchor rules.
-- `deprecation-triage` (`skills/deprecation-triage/SKILL.md`): deprecation
-  warning triage workflow and issue template.
-
-## Usage conventions
-- Keep skills minimal and procedural; defer rationale to the standards.
-- Update skills when the referenced standards change.
-- Do not duplicate standards verbatim; link to canonical docs instead.
-- Autocomplete favors distinct skill names; summarize wrappers exist so teams
-  can select a mode without typing additional arguments.
-
-## Downstream references
-Add a short reference to these skills in downstream `AGENTS.md` files using
-placeholders for the local path to the standards repository.
-
-Example snippet (replace placeholders):
-```
-## Shared skills
-- Load all skills from: <standards-repo-path>/skills/**/SKILL.md
-- Treat every skill found under that directory as available and active.
-```
+## Usage
+- Treat this directory as a reference library, not a runtime dependency.
+- Copy any required skill into the target repository before using it.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,13 +1,58 @@
-# Skills library
+# Skills overview
 
 ## Table of Contents
 - [Purpose](#purpose)
-- [Usage](#usage)
+- [Scope](#scope)
+- [Skill list](#skill-list)
+- [Usage conventions](#usage-conventions)
+- [Dependency policy](#dependency-policy)
+- [Downstream references](#downstream-references)
 
 ## Purpose
-Provide shared skills that repositories can copy into their own `skills/`
-directories when needed.
+Provide a canonical, repository-managed set of Codex skills derived from the
+standards in this repository.
 
-## Usage
-- Treat this directory as a reference library, not a runtime dependency.
-- Copy any required skill into the target repository before using it.
+## Scope
+These skills are shared across repositories that adopt the standards here.
+Skill bodies must remain aligned with the canonical documents they reference.
+
+## Skill list
+- `summarize` (`skills/summarize/SKILL.md`): multi-mode summarization for
+  decisions, operations, and SOC capture.
+- `summarize-decisions` (`skills/summarize-decisions/SKILL.md`): wrapper for
+  decisions summaries (autocomplete-friendly).
+- `summarize-operations` (`skills/summarize-operations/SKILL.md`): wrapper for
+  operations summaries (autocomplete-friendly).
+- `summarize-soc` (`skills/summarize-soc/SKILL.md`): wrapper for SOC capture
+  summaries (autocomplete-friendly).
+- `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow with
+  docs-only exception handling.
+- `dependency-update` (`skills/dependency-update/SKILL.md`): dependency update
+  workflow with failure handling and anchor rules.
+- `deprecation-triage` (`skills/deprecation-triage/SKILL.md`): deprecation
+  warning triage workflow and issue template.
+
+## Usage conventions
+- Keep skills minimal and procedural; defer rationale to the standards.
+- Update skills when the referenced standards change.
+- Do not duplicate standards verbatim; link to canonical docs instead.
+- Autocomplete favors distinct skill names; summarize wrappers exist so teams
+  can select a mode without typing additional arguments.
+
+## Dependency policy
+- Treat this directory as a reference library.
+- Copy shared skills into the target repository’s `skills/` directory before
+  using them.
+- Do not rely on symlinks or external paths for required skills.
+- Skills are not auto-registered; restart the agent session after adding them.
+
+## Downstream references
+Add a short reference to these skills in downstream `AGENTS.md` files using
+placeholders for the local path to the standards repository.
+
+Example snippet (replace placeholders):
+```
+## Shared skills
+- Load all skills from: <standards-repo-path>/skills/**/SKILL.md
+- Treat every skill found under that directory as available and active.
+```


### PR DESCRIPTION
# Pull Request

## Summary
- Add canonical guidance for repo-local skills and shared skills library usage.
- Add `skills/` to the default repository layout and expand skills library notes.

## Issue Linkage
- Fixes #73

## Testing
- Docs-only: tests skipped.

## Notes
- Docs-only: tests skipped.
- Files changed:
  - docs/foundation/agent-skills.md
  - docs/repository/repository-structure.md
  - skills/README.md
