### PR TITLE
Require repository type in standards entrypoint

### DIFF
--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -4,6 +4,8 @@
 - [Purpose](#purpose)
 - [Requirement](#requirement)
 - [Canonical references](#canonical-references)
+  - [Core references (always required)](#core-references-always-required)
+  - [Repository-type references (required for the declared type)](#repository-type-references-required-for-the-declared-type)
 - [Project-specific overlay](#project-specific-overlay)
 - [Template](#template)
 - [Maintenance](#maintenance)
@@ -17,15 +19,36 @@ Every repository must include `docs/standards-and-conventions.md`.
 
 This file must:
 - reference the canonical standards in this repository using GitHub URLs
+- list all required canonical references for the repository
 - document project-specific information and deviations
+- include a complete repository profile with concrete values
 - avoid duplicating canonical standards verbatim
 
 If the canonical standards cannot be retrieved, treat it as a fatal exception
 and notify the user.
 
+Repository profiles must explicitly declare `repository_type` and must not
+contain placeholder values (for example, `<application|library|documentation>`).
+If any required attribute is missing or left as a placeholder, treat it as a
+fatal exception and stop.
+
 ## Canonical references
 Include links to the canonical documents that apply to the repository. Use
-GitHub URLs pointing to this repository.
+GitHub URLs pointing to this repository. The lists below are required for this
+repository and serve as the minimum baseline for other repositories.
+Include only the repository-type references that match the declared
+`repository_type`.
+
+### Core references (always required)
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/repository-types-and-attributes.md
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/github-issues.md
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
+
+### Repository-type references (required for the declared type)
+- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/documentation-branching-model.md
 
 ## Project-specific overlay
 Record project-specific details here, such as:
@@ -41,11 +64,11 @@ rules unless a deviation exists.
   - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
   - Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
 - Repository profile:
-  - repository_type: <application|library|documentation>
-  - versioning_scheme: <application|library|ecosystem-specific|none>
-  - branching_model: <application-promotion|library-release|docs-single-branch>
-  - release_model: <environment-promotion|artifact-publishing|none>
-  - supported_release_lines: <single|list of MAJOR.MINOR lines|none>
+  - repository_type: documentation
+  - versioning_scheme: none
+  - branching_model: docs-single-branch
+  - release_model: none
+  - supported_release_lines: none
 
 ## Template
 ```
@@ -59,7 +82,23 @@ https://github.com/<org>/<standards-repo>
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-- <link to relevant canonical docs>
+Include only the repository-type references that match the declared
+`repository_type`.
+
+### Core references (always required)
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/foundation/markdown-standards.md
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/repository-types-and-attributes.md
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/commit-messages-and-authorship.md
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/github-issues.md
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/pull-request-workflow.md
+- https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/source-control-guidelines.md
+
+### Repository-type references (required for the declared type)
+- Documentation repositories: https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/documentation-branching-model.md
+- Application repositories: https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/branching-and-deployment.md
+- Application repositories: https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/application-versioning-scheme.md
+- Library repositories: https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/library-branching-and-release.md
+- Library repositories: https://github.com/<org>/<standards-repo>/blob/<default-branch>/docs/code-management/library-versioning-scheme.md
 
 ## Project-specific overlay
 - AI co-authors:


### PR DESCRIPTION
# Pull Request

## Summary
- Require explicit repository type declaration and expand canonical references in the standards entrypoint.

## Issue Linkage
- Ref #80
- Work is not complete until the issue is closed.

## Testing
- Not run (docs-only; no validation command documented).

## Notes
- Docs-only: tests skipped.
- Files changed: `docs/standards-and-conventions.md`.
