### PR TITLE
Update repository includes and import context-bootstrap skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Standards and Conventions - Agent Instructions
 
 #include docs/standards-and-conventions.md
-#include docs/repository-standards.md
+#include ./docs/repository-standards.md
 
 ## User Overrides (Optional)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Standards and Conventions - Agent Instructions
 
-#include standards-and-conventions.md
+#include docs/standards-and-conventions.md
+#include docs/repository-standards.md
 
 ## User Overrides (Optional)
 

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -26,3 +26,11 @@ Correction applied:
 ## Prompt shortcuts
 Use a standalone prompt that invokes the log, such as:
 - `Log cognitive drift`
+
+Date: 2026-01-22
+Context: Replacing the repository's `skills/context-bootstrap` with the home directory copy after unexpected changes were detected.
+Prompt: "Please import the context-bootstrap skill from my home dir into this repo for reference, replacing the current one entirely -- again"
+Observed failure: Proceeded with the file copy instead of stopping immediately to ask how to handle unexpected changes.
+Category (A–F): F
+Severity (Soft / Hard): Hard
+Correction applied: Stop on unexpected changes and ask how to proceed before any further action.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,0 +1,20 @@
+# Standards and Conventions Repository Standards
+
+## Table of Contents
+- [AI co-authors](#ai-co-authors)
+- [Repository profile](#repository-profile)
+- [Local deviations](#local-deviations)
+
+## AI co-authors
+- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
+
+## Repository profile
+- repository_type: documentation
+- versioning_scheme: none
+- branching_model: docs-single-branch
+- release_model: none
+- supported_release_lines: none
+
+## Local deviations
+- None.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -21,7 +21,7 @@ This file must:
 - make the required canonical references discoverable via a direct list or an
   include chain
 - document project-specific information and deviations inline or via
-  `#include repository-standards.md`
+  `#include ./repository-standards.md`
 - include a complete repository profile with concrete values
 - avoid duplicating canonical standards verbatim
 
@@ -98,15 +98,7 @@ Record project-specific details here, such as:
 Project-specific content must be explicit and scoped. Do not restate canonical
 rules unless a deviation exists.
 
-- AI co-authors:
-  - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-  - Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-- Repository profile:
-  - repository_type: documentation
-  - versioning_scheme: none
-  - branching_model: docs-single-branch
-  - release_model: none
-  - supported_release_lines: none
+#include ./repository-standards.md
 
 ## Template
 ```
@@ -126,7 +118,7 @@ rules unless a deviation exists.
 #include ../standards-and-conventions/docs/standards-and-conventions.md
 
 ## Project-specific overlay
-#include repository-standards.md
+#include ./repository-standards.md
 ```
 
 ```

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -21,7 +21,7 @@ This file must:
 - make the required canonical references discoverable via a direct list or an
   include chain
 - document project-specific information and deviations inline or via
-  `#include ./repository-standards.md`
+  `docs/repository-standards.md` (included from `AGENTS.md`)
 - include a complete repository profile with concrete values
 - avoid duplicating canonical standards verbatim
 
@@ -98,13 +98,14 @@ Record project-specific details here, such as:
 Project-specific content must be explicit and scoped. Do not restate canonical
 rules unless a deviation exists.
 
-#include ./repository-standards.md
+Project-specific content must live in `docs/repository-standards.md` and be
+included from `AGENTS.md` only. Do not include it here.
 
 ## Template
 ```
 # <Repository> Standards Bootstrap
 
-#include docs/standards-and-conventions.md
+  #include docs/standards-and-conventions.md
 ```
 
 ```
@@ -115,10 +116,10 @@ rules unless a deviation exists.
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-#include ../standards-and-conventions/docs/standards-and-conventions.md
+  #include ../standards-and-conventions/docs/standards-and-conventions.md
 
 ## Project-specific overlay
-#include ./repository-standards.md
+  See `docs/repository-standards.md` (included from `AGENTS.md`).
 ```
 
 ```

--- a/skills/context-bootstrap/SKILL.md
+++ b/skills/context-bootstrap/SKILL.md
@@ -6,11 +6,38 @@ description: Bootstrap context by reading AGENTS and standards include chains an
 # Context Bootstrap
 
 ## Goal
-Read the startup instruction chain and report only the ordered list of file paths read.
+Read the startup instruction chain and output the ordered file paths as they are encountered.
+
+## Intent and constraints (non-negotiable)
+- This is a fast, literal read-through. Treat it like reading a short bash script.
+- The purpose is to bootstrap session context by consuming the ordered include chain.
+- Do not pause for planning, clarification, or optimization. Execute immediately.
+- Do not run the script more than once.
+- Do not run any other shell commands before or after. The script invocation is
+  the only allowed command. No pipes, redirection, or post-processing.
+- Do not emit any meta-commentary or planning lines (for example “Identifying…”, “Clarifying…”, “Planning…”).
+- Use the provided script `scripts/context_bootstrap_paths.py` to resolve includes
+  and emit an ordered list of paths only. Do not improvise alternate parsing or optimization.
+- The script reads local files only and expands includes recursively.
+- `../standards-and-conventions/` must exist locally or the script fails.
+- The script output (or missing path) is authoritative.
+- If an include is missing, stop and report the missing path.
 
 ## Entry points
 1. Read `~/AGENTS.md` if it exists.
 2. Read `./AGENTS.md`.
+
+## Script usage
+Run exactly this command once (no pipes, no extra commands):
+`python3 ~/.codex/skills/context-bootstrap/scripts/context_bootstrap_paths.py --repo-root <repo-root>`
+
+Processing rules (exact):
+1. Read the script output stream directly and check the script exit code. Do not re-run
+   the script or invoke any other commands to filter or reformat the output.
+2. If the script exits with code 0, for every line in the script output, immediately output
+   `Reading: <path>` on its own line.
+3. If the script exits with a nonzero code, output the script’s error line(s) verbatim and stop.
+4. Do not add any other lines. No final summary block.
 
 ## Include syntax
 - Include lines must start with `#include` followed by a path.
@@ -29,14 +56,11 @@ Read the startup instruction chain and report only the ordered list of file path
 Resolve relative include paths in this order, using the repo root (the cwd at bootstrap) as the base:
 1. `./` (repo root)
 2. `../standards-and-conventions/`
-3. `https://raw.githubusercontent.com/wphillipmoore/standards-and-conventions/develop/`
 
 ### Standards repo prefix handling
 If a relative include path starts with `../standards-and-conventions/`:
 1. Try it locally relative to the repo root.
-2. If not found, strip the prefix and retry via the GitHub base URL.
 
 ## Output
-- After completing all required reads, print the ordered list of file paths (or URLs) read, one per line.
-- The list must be the final output before returning control to the user.
-- Do not include file contents or reasons in the final list.
+- Output `Reading: <path>` for each file path as it is encountered.
+- Do not include file contents or reasons in the output.

--- a/skills/context-bootstrap/scripts/context_bootstrap_paths.py
+++ b/skills/context-bootstrap/scripts/context_bootstrap_paths.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Resolve context-bootstrap include paths and emit ordered path list."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+STANDARDS_PREFIX = "../standards-and-conventions/"
+
+
+class MissingInclude(Exception):
+    def __init__(self, path: str, source: str | None = None) -> None:
+        self.path = path
+        self.source = source
+        message = f"Missing include: {path}"
+        if source:
+            message = f"{message} (referenced from: {source})"
+        super().__init__(message)
+
+
+def is_absolute(path: str) -> bool:
+    return path.startswith("/") or path.startswith("~")
+
+
+def strip_include(raw: str) -> str:
+    raw = raw.strip()
+    if raw.startswith("\"") and raw.endswith("\""):
+        return raw[1:-1]
+    if raw.startswith("<") and raw.endswith(">"):
+        return raw[1:-1]
+    return raw
+
+
+def read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def resolve_include(repo_root: str, include_path: str) -> str | None:
+    if not include_path:
+        return None
+
+    if is_absolute(include_path):
+        return os.path.abspath(os.path.expanduser(include_path))
+
+    if include_path.startswith(STANDARDS_PREFIX):
+        local_path = os.path.abspath(os.path.join(repo_root, include_path))
+        if os.path.isfile(local_path):
+            return local_path
+        return None
+
+    repo_candidate = os.path.abspath(os.path.join(repo_root, include_path))
+    if os.path.isfile(repo_candidate):
+        return repo_candidate
+
+    standards_candidate = os.path.abspath(
+        os.path.join(repo_root, "../standards-and-conventions", include_path)
+    )
+    if os.path.isfile(standards_candidate):
+        return standards_candidate
+    return None
+
+
+def iter_includes(content: str) -> list[str]:
+    includes: list[str] = []
+    for line in content.splitlines():
+        if line.startswith("#include ") or line.startswith("#include\t"):
+            include_path = strip_include(line[len("#include") :])
+            includes.append(include_path)
+    return includes
+
+
+def resolve_chain(repo_root: str) -> list[tuple[str, str]]:
+    ordered: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    standards_repo_present = os.path.isdir(
+        os.path.abspath(os.path.join(repo_root, "../standards-and-conventions"))
+    )
+    if not standards_repo_present:
+        raise MissingInclude(os.path.abspath(os.path.join(repo_root, "../standards-and-conventions")))
+
+    def process(path: str, source: str | None = None) -> None:
+        if path in seen:
+            return
+        seen.add(path)
+        try:
+            content = read_text(path)
+        except FileNotFoundError:
+            raise MissingInclude(path, source=source)
+        ordered.append((path, content))
+        for include_path in iter_includes(content):
+            resolved = resolve_include(repo_root, include_path)
+            if resolved is None:
+                raise MissingInclude(include_path, source=path)
+            process(resolved, source=path)
+
+    home_agents = os.path.expanduser("~/AGENTS.md")
+    if os.path.isfile(home_agents):
+        process(os.path.abspath(home_agents))
+
+    repo_agents = os.path.abspath(os.path.join(repo_root, "AGENTS.md"))
+    if os.path.isfile(repo_agents):
+        process(repo_agents)
+
+    return ordered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve context-bootstrap includes and emit ordered path list."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.getcwd(),
+        help="Repository root for resolving relative includes (default: current working directory).",
+    )
+    args = parser.parse_args()
+
+    repo_root = os.path.abspath(os.path.expanduser(args.repo_root))
+
+    try:
+        ordered = resolve_chain(repo_root)
+    except MissingInclude as exc:
+        raise SystemExit(str(exc))
+
+    for path, _content in ordered:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Update repository include guidance and reference `docs/repository-standards.md` only from `AGENTS.md`.
- Import the latest `context-bootstrap` skill and helper script from the home directory.

## Issue Linkage
- Fixes #84

## Testing
- Docs-only: tests skipped (documentation repository; no required validation command).

## Notes
- None.
