### PR TITLE
Clarify auto-merge default command

### DIFF
--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -122,6 +122,11 @@ Opt out when a merge must be scheduled or reviewed by adding the label
 `manual-merge` to the pull request. Do not enable auto-merge while that label
 is present.
 
+When asked to submit or finalize a PR, enable auto-merge using
+`gh pr merge --auto --merge --delete-branch` without prompting for a merge
+method unless `manual-merge` is present or auto-merge is disabled for the
+repository.
+
 If auto-merge is disabled for the repository, follow the manual merge steps and
 wait for all required checks to pass before merging.
 


### PR DESCRIPTION
# Pull Request

## Summary
- Clarify the default auto-merge command and no-prompt rule in the PR workflow.

## Issue Linkage
- Fixes #86

## Testing
- Docs-only: tests skipped

## Notes
- Files changed: docs/code-management/pull-request-workflow.md
