### PR TITLE
docs: log issue-creation drift and clarify guidance

### DIFF
--- a/docs/code-management/github-issues.md
+++ b/docs/code-management/github-issues.md
@@ -60,6 +60,10 @@ Required configuration:
 ## Issue creation and linking
 - If a human already specified an issue, use it as the primary issue.
 - If no issue exists, create one before creating a branch or changing files.
+- If no issue exists, create it immediately using best-effort assumptions and
+  explicitly note those assumptions in the issue body. Do not delay work by
+  asking for an issue number unless acceptance criteria are materially
+  ambiguous.
 - The PR description must link to the primary issue.
 - If an issue has no special acceptance criteria, include a closing keyword in
   the PR description so the issue auto-closes on merge.

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -34,3 +34,20 @@ Observed failure: Proceeded with the file copy instead of stopping immediately t
 Category (A–F): F
 Severity (Soft / Hard): Hard
 Correction applied: Stop on unexpected changes and ask how to proceed before any further action.
+
+Date: 2026-01-27
+Context: Standards-and-conventions repo. User asked to import the context-bootstrap skill from ~/.codex. This required creating a GitHub issue before branching or file changes.
+Prompt: "Import the context-bootstrap skill from ~/.codex to this repo, as a reference"
+Observed failure: I asked the user for an issue number instead of creating a new GitHub issue myself. This directly violated the documented rule to create an issue when none exists before branching or changing files. It also inverted the intended behavior of context-bootstrap: the standards were loaded, but I treated them as optional guidance rather than binding workflow steps.
+Why this happened (analysis):
+- I over-weighted a generic "ask for missing inputs" instinct and treated issue creation as blocked without user-provided fields, despite the explicit rule to create the issue when missing.
+- I failed to operationalize the standard into a concrete action (create issue now, mark assumptions) and instead deferred responsibility to the user, which is contrary to the documentation-first workflow.
+- I did not apply the "Question-Asking Bias" requirement to act first when the decision is reversible; creating an issue is reversible and should have been done immediately with best-effort assumptions.
+- I missed a guardrail opportunity: no explicit self-check that a GitHub issue exists before any other workflow steps.
+Category (A–F): F
+Severity (Soft / Hard): Hard
+Correction applied:
+- Immediately created issue #90 to track the remediation.
+- Added a required guardrail: before any branch or file edits, check for an existing issue; if absent, create one immediately using best-effort assumptions and clearly mark those assumptions in the issue body.
+- Update standards/skill guidance to explicitly forbid asking the user for an issue number when the issue does not yet exist unless acceptance criteria are materially ambiguous.
+- Added this verbose drift log entry to capture root-cause hypotheses and prevent recurrence.

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -19,6 +19,9 @@ Follow local overrides (AGENTS or repo-specific standards) when present.
 
 ## Preflight
 - Confirm you are working on a short-lived branch per branching rules.
+- If no primary issue exists, create one immediately using best-effort
+  assumptions and note them in the issue body. Do not ask for an issue number
+  unless acceptance criteria are materially ambiguous.
 - Locate the pull request template at `.github/pull_request_template.md`.
 - Ensure commit message format and AI co-authorship requirements are met per
   the commit standards and the repo's approved AI identity list.


### PR DESCRIPTION
# Pull Request

## Summary
- Logged the issue-creation compliance failure in the cognitive drift log.
- Clarified immediate issue-creation expectations in standards and the PR workflow skill.

## Issue Linkage
- Ref #90

## Testing
- Not run (documentation repository; no canonical validation command documented)

## Notes
- N/A