### PR TITLE
docs: tighten bootstrap guardrails

### DIFF
--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -16,6 +16,7 @@ Use before finalizing any response governed by the interaction contract.
 ## Checklist
 - Problem constraints are explicit.
 - Assumptions are stated.
+- Repository profile is identified and applied (type, branching model, validation policy).
 - No silent guessing of material facts.
 - Weak premises were challenged.
 - No unnecessary abstraction introduced.

--- a/docs/foundation/cognitive-regression-tests.md
+++ b/docs/foundation/cognitive-regression-tests.md
@@ -25,6 +25,9 @@ Use when validating conformance to the interaction contract.
 ## Failure criteria
 Any hard failure indicates contract drift and requires correction.
 
+Hard failures include:
+- Proceeding without applying the repository profile when it materially affects workflow (for example, a documentation repository that still demands validation or uses the wrong branching model).
+
 ## Prompt shortcuts
 Use a standalone prompt that invokes the tests, such as:
 - `Run cognitive regression tests`

--- a/skills/context-bootstrap/SKILL.md
+++ b/skills/context-bootstrap/SKILL.md
@@ -55,6 +55,15 @@ Processing rules (exact):
 4. If the script exits with a nonzero code, output the script’s error line(s) verbatim and stop.
 5. Do not add any other lines. No final summary block.
 
+## Post-bootstrap response requirement
+- Before any other action, the next assistant response MUST begin with a
+  "Standards snapshot" block.
+- The snapshot MUST explicitly state: `repository_type`, `branching_model`,
+  docs-only scope or exception, and validation policy (required vs optional,
+  plus the canonical command if documented).
+- If any item is unknown or missing, state that explicitly and stop before
+  acting.
+
 ## Include syntax
 - Include lines must start with `#include` followed by a path.
 - Accepted forms:


### PR DESCRIPTION
# Pull Request

## Summary
- Add bootstrap guardrails to force repository-profile acknowledgment and regression-test coverage.

## Issue Linkage
- Ref #94
- Work is not complete until the issue is closed.

## Testing
- Docs-only: tests skipped
- Files changed: `docs/foundation/agent-pre-response-checklist.md`, `docs/foundation/cognitive-regression-tests.md`, `skills/context-bootstrap/SKILL.md`

## Notes
- Validation not run; no canonical command documented.
