### PR TITLE
docs: add RTFM protocol handling

### DIFF
--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -16,6 +16,8 @@ Use before finalizing any response governed by the interaction contract.
 ## Checklist
 - Problem constraints are explicit.
 - Assumptions are stated.
+- If the prompt starts with `RTFM`, switch to the RTFM protocol and suspend
+  normal work.
 - Repository profile is identified and applied (type, branching model, validation policy).
 - No silent guessing of material facts.
 - Weak premises were challenged.

--- a/docs/foundation/interaction-contract-brief.md
+++ b/docs/foundation/interaction-contract-brief.md
@@ -8,6 +8,7 @@
 - [Optimization invariants](#optimization-invariants)
 - [Communication requirements](#communication-requirements)
 - [Failure signaling](#failure-signaling)
+- [RTFM protocol](#rtfm-protocol)
 - [Anti-goals](#anti-goals)
 - [Prompt shortcuts](#prompt-shortcuts)
 
@@ -46,6 +47,11 @@ correctness.
 Ill-posed or underspecified problems MUST be called out explicitly. Silent
 accommodation is failure.
 
+## RTFM protocol
+If a user message starts with `RTFM`, pause normal work, identify the violated
+standard(s), ask what was unclear, and create an issue in the current
+repository labeled `rtfm` to track the documentation fix.
+
 ## Anti-goals
 Politeness over correctness, vibe-coding, premature generality, and reliance on
 human heroics are prohibited.
@@ -53,3 +59,4 @@ human heroics are prohibited.
 ## Prompt shortcuts
 Use a standalone prompt that invokes the protocol, such as:
 - `Show interaction contract brief`
+- `RTFM <reason>`

--- a/docs/foundation/interaction-contract.md
+++ b/docs/foundation/interaction-contract.md
@@ -8,6 +8,7 @@
 - [Optimization invariants](#optimization-invariants)
 - [Communication requirements](#communication-requirements)
 - [Failure signaling](#failure-signaling)
+- [RTFM protocol](#rtfm-protocol)
 - [Anti-goals](#anti-goals)
 - [Agent self-check rubric](#agent-self-check-rubric)
 - [Prompt shortcuts](#prompt-shortcuts)
@@ -62,6 +63,32 @@ correctness.
 - The assistant MUST NOT silently accommodate ambiguity.
 - The minimum clarification needed to proceed SHOULD be proposed.
 
+## RTFM protocol
+RTFM is a forced interruption that indicates a standards violation or a missed
+requirement that should have been clear from the governing documentation.
+
+Trigger:
+- A user message that starts with `RTFM` (case-insensitive).
+- The optional reason after `RTFM` is a hint about the violated standards.
+
+Required steps:
+1. Pause all other work and enter RTFM handling before answering any other
+   request.
+2. Identify the violated standards with exact document paths and section
+   headings, and state how the response diverged.
+3. Ask the user what was unclear or insufficient in the standards; use the
+   optional reason to focus the question.
+4. Create a GitHub issue in the current repository to track the cognitive
+   failure and the documentation gap.
+5. Propose and, when feasible, implement documentation updates that prevent
+   recurrence before resuming normal work.
+
+Issue requirements:
+- Title format: `RTFM: <short failure summary>`
+- Body MUST include: violated standard(s), what was unclear, and the proposed
+  documentation update.
+- Apply label `rtfm`.
+
 ## Anti-goals
 The assistant MUST NOT optimize for:
 - performative helpfulness
@@ -87,3 +114,4 @@ If any check fails, the response MUST be revised.
 ## Prompt shortcuts
 Use a standalone prompt that invokes the protocol, such as:
 - `Load interaction contract`
+- `RTFM <reason>`


### PR DESCRIPTION
# Pull Request

## Summary
- Add RTFM protocol guidance and checklist handling.

## Issue Linkage
- Fixes #96

## Testing
- Docs-only: tests skipped

## Notes
- Files changed: docs/foundation/interaction-contract.md, docs/foundation/interaction-contract-brief.md, docs/foundation/agent-pre-response-checklist.md
