### PR TITLE
Add enforcement gates and RTFM evidence capture

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,44 @@
+name: Issue
+description: Track work with explicit acceptance criteria.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to capture the required issue details.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short, single-paragraph summary.
+      placeholder: What is the change or problem?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Goal
+      description: What is broken or what outcome is needed?
+    validations:
+      required: true
+  - type: checkboxes
+    id: acceptance_obvious
+    attributes:
+      label: Acceptance criteria clarity
+      options:
+        - label: Criteria are obvious (docs-only or trivial change)
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria (if not obvious)
+      description: If criteria are obvious, write "Obvious" with a short note.
+      placeholder: List explicit criteria or success conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Evidence
+      description: How will completion be verified?
+    validations:
+      required: true

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -33,6 +33,9 @@ PR description and list the files changed.
 
 Documentation repositories may define "docs-only" as the entire repository and
 keep validation optional unless the repository documents a required check.
+For documentation repositories with no documented validation command, do not
+ask for validation; state that validation is optional and proceed with PR
+submission.
 
 CI workflows must implement the docs-only skip policy in
 [source-control-guidelines.md](source-control-guidelines.md#docs-only-ci-skip-policy).

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -16,6 +16,7 @@
 - [5. CI/CD Constraints](#5-cicd-constraints)
   - [CI gates](#ci-gates)
   - [Docs-only CI skip policy](#docs-only-ci-skip-policy)
+  - [Local enforcement hooks](#local-enforcement-hooks)
 - [6. Locked vs. Flexible Decisions](#6-locked-vs-flexible-decisions)
   - [Locked at v0.1](#locked-at-v01)
   - [Explicitly Flexible](#explicitly-flexible)
@@ -158,6 +159,33 @@ them with the docs-only output. Dependency audits should still run by default;
 if a repository chooses to skip them, it must document the exception.
 
 Docs-only validation commands, when defined, must still run.
+
+### Local enforcement hooks
+Use local Git hooks to fail closed on branch protection rules that should
+never be violated.
+
+Minimum requirement:
+- Install a `pre-commit` hook that blocks commits on protected branches
+  (`develop`, `release`, `main`, and `release/*`).
+- Store hooks in-repo (for example, `scripts/git-hooks/`) and set
+  `core.hooksPath` locally so the hooks are enabled.
+- Hooks must print a clear, actionable error and exit non-zero on violations.
+
+Example hook (store as `scripts/git-hooks/pre-commit` and mark executable):
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+case "$branch" in
+  develop|release|main|release/*)
+    echo "ERROR: direct commits to protected branches are forbidden ($branch)." >&2
+    echo "Create a short-lived branch (feature/* or bugfix/*) and open a PR." >&2
+    exit 1
+    ;;
+esac
+```
 
 ---
 

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -19,6 +19,7 @@ Use before finalizing any response governed by the interaction contract.
 - If the prompt starts with `RTFM`, switch to the RTFM protocol and suspend
   normal work.
 - Repository profile is identified and applied (type, branching model, validation policy).
+- Preflight gate emitted before any file edit or git action (branch, issue, docs-only scope, validation policy).
 - No silent guessing of material facts.
 - Weak premises were challenged.
 - No unnecessary abstraction introduced.

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -20,6 +20,7 @@ Use before finalizing any response governed by the interaction contract.
   normal work.
 - Repository profile is identified and applied (type, branching model, validation policy).
 - Preflight gate emitted before any file edit or git action (branch, issue, docs-only scope, validation policy).
+- For documentation repositories with no documented validation command, do not ask for validation; proceed with PR workflow.
 - No silent guessing of material facts.
 - Weak premises were challenged.
 - No unnecessary abstraction introduced.

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -18,6 +18,7 @@ Date:
 Context:
 Prompt:
 Observed failure:
+State snapshot (branch, git status, files touched):
 Category (A–F):
 Severity (Soft / Hard):
 Correction applied:

--- a/docs/foundation/cognitive-regression-tests.md
+++ b/docs/foundation/cognitive-regression-tests.md
@@ -26,7 +26,11 @@ Use when validating conformance to the interaction contract.
 Any hard failure indicates contract drift and requires correction.
 
 Hard failures include:
-- Proceeding without applying the repository profile when it materially affects workflow (for example, a documentation repository that still demands validation or uses the wrong branching model).
+- Proceeding without applying the repository profile when it materially
+  affects workflow (for example, a documentation repository that still
+  demands validation or uses the wrong branching model).
+- Performing a file edit or git action without emitting the required preflight
+  gate.
 
 ## Prompt shortcuts
 Use a standalone prompt that invokes the tests, such as:

--- a/docs/foundation/interaction-contract-brief.md
+++ b/docs/foundation/interaction-contract-brief.md
@@ -48,8 +48,9 @@ Ill-posed or underspecified problems MUST be called out explicitly. Silent
 accommodation is failure.
 
 ## RTFM protocol
-If a user message starts with `RTFM`, pause normal work, identify the violated
-standard(s), ask what was unclear, and create an issue in the current
+If a user message starts with `RTFM`, pause normal work, capture the failure
+context (branch, git status, files touched, action sequence), identify the
+violated standard(s), ask what was unclear, and create an issue in the current
 repository labeled `rtfm` to track the documentation fix.
 
 ## Anti-goals

--- a/docs/foundation/interaction-contract.md
+++ b/docs/foundation/interaction-contract.md
@@ -74,19 +74,22 @@ Trigger:
 Required steps:
 1. Pause all other work and enter RTFM handling before answering any other
    request.
-2. Identify the violated standards with exact document paths and section
+2. Capture the failure context with concrete evidence (branch, git status,
+   files touched, and the action sequence that triggered the violation).
+3. Identify the violated standards with exact document paths and section
    headings, and state how the response diverged.
-3. Ask the user what was unclear or insufficient in the standards; use the
+4. Ask the user what was unclear or insufficient in the standards; use the
    optional reason to focus the question.
-4. Create a GitHub issue in the current repository to track the cognitive
+5. Create a GitHub issue in the current repository to track the cognitive
    failure and the documentation gap.
-5. Propose and, when feasible, implement documentation updates that prevent
+6. Propose and, when feasible, implement documentation updates that prevent
    recurrence before resuming normal work.
 
 Issue requirements:
 - Title format: `RTFM: <short failure summary>`
-- Body MUST include: violated standard(s), what was unclear, and the proposed
-  documentation update.
+- Body MUST include: violated standard(s), what was unclear, failure context
+  evidence, the missing or bypassed gate, and the proposed documentation
+  update.
 - Apply label `rtfm`.
 
 ## Anti-goals

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+case "$branch" in
+  develop|release|main|release/*)
+    echo "ERROR: direct commits to protected branches are forbidden ($branch)." >&2
+    echo "Create a short-lived branch (feature/* or bugfix/*) and open a PR." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
# Pull Request

## Summary
- Add enforcement gates (preflight requirement + protected-branch hook) and issue templates
- Extend RTFM protocol to capture failure context evidence
- Clarify validation handling for documentation repositories

## Issue Linkage
- Ref #98
- Ref #99
- Ref #100
- Work is not complete until the issue is closed.

## Testing
- Not required (documentation repository; no canonical validation command documented)

## Notes
- Includes repo-local `scripts/git-hooks/pre-commit` and issue form templates
