### PR TITLE
docs: enforce standards snapshot after context-bootstrap

### DIFF
--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -19,6 +19,7 @@ Use before finalizing any response governed by the interaction contract.
 - If the prompt starts with `RTFM`, switch to the RTFM protocol and suspend
   normal work.
 - Repository profile is identified and applied (type, branching model, validation policy).
+- If context-bootstrap was run, the next response begins with the Standards Snapshot block.
 - Preflight gate emitted before any file edit or git action (branch, issue, docs-only scope, validation policy).
 - For documentation repositories with no documented validation command, do not ask for validation; proceed with PR workflow.
 - No silent guessing of material facts.


### PR DESCRIPTION
# Pull Request

## Summary
- Add checklist guardrail requiring the Standards Snapshot after context-bootstrap.

## Issue Linkage
- Fixes #102
- Work is not complete until the issue is closed.

## Testing
- Docs-only: tests skipped.
- Files changed:
  - docs/foundation/agent-pre-response-checklist.md

## Notes
- None.
