### PR TITLE
chore: add markdownlint validation baseline

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,15 @@
+default: true
+MD005: false
+MD007: false
+MD018: false
+MD022: false
+MD031: false
+MD032: false
+MD037: false
+MD013: false
+MD024: false
+MD026: false
+MD033: false
+MD034: false
+MD040: false
+MD060: false

--- a/docs/code-management/documentation-branching-model.md
+++ b/docs/code-management/documentation-branching-model.md
@@ -64,8 +64,9 @@ Rules:
 - deleted after merge
 
 ## 6. Validation expectations
-Documentation repositories do not require automated test or release validation.
-Keep validation optional unless a specific repository documents a requirement.
+Documentation repositories must run markdownlint for documentation validation.
+Automated test or release validation is not required. Additional validation is
+optional unless a specific repository documents a requirement.
 
 ## 7. Forbidden operations
 - direct commits to `develop`

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -33,14 +33,14 @@ When using this exception, explicitly state `Docs-only: tests skipped` in the
 PR description and list the files changed.
 
 Documentation repositories may define "docs-only" as the entire repository and
-keep validation optional unless the repository documents a required check.
-For documentation repositories with no documented validation command, do not
-ask for validation; state that validation is optional and proceed with PR
-submission.
+require markdownlint. Additional validation is optional unless the repository
+documents a requirement. For documentation repositories with only markdownlint
+required, do not ask for additional validation; proceed with PR submission.
 
 CI workflows must implement the docs-only skip policy in
 [source-control-guidelines.md](source-control-guidelines.md#docs-only-ci-skip-policy).
-If a docs-only validation command exists, run it even when tests are skipped.
+Markdownlint and any docs-only validation commands must still run even when
+tests are skipped.
 
 ## Issue linkage
 Every pull request must have a primary GitHub issue. If no issue exists,
@@ -72,14 +72,16 @@ Minimum required template:
 - If no issue exists, open one before any work begins.
 
 ## Testing
-- <canonical validation command>
+- markdownlint
+- <language-specific validation command, if applicable>
+- <repo-specific validation command, if applicable>
 
 ## Notes
 - 
 ```
 
-If the repository defines a canonical local validation command, the template
-must list it in the Testing section.
+The template must list markdownlint and any additional required validation
+commands in the Testing section.
 
 ## Pre-Submission Requirements
 Before creating a pull request, all of the following must be met unless the
@@ -89,13 +91,15 @@ docs-only exception applies:
 3. All hard-gate code quality checks must pass
 4. Soft-gate failures must be disclosed and tracked
 
-Each repository must document its canonical local validation command. If one
-exists, it is the required pre-submission run.
+Each repository must document its canonical local validation command(s).
+Markdownlint is required for all repositories and must be part of the
+pre-submission run. Additional commands are required when documented.
 
 ## Pre-Submission Checklist
-Use the repository's canonical validation command when available.
+Use the repository's canonical validation command(s) when available.
 
 If no single command exists, run:
+- markdownlint
 - full test suite
 - linting
 - type checking

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -158,7 +158,7 @@ When `docs_only` is `true`, skip test and version-validation jobs by gating
 them with the docs-only output. Dependency audits should still run by default;
 if a repository chooses to skip them, it must document the exception.
 
-Docs-only validation commands, when defined, must still run.
+Markdownlint and any docs-only validation commands must still run.
 
 ### Local enforcement hooks
 Use local Git hooks to fail closed on branch protection rules that should

--- a/docs/development/database/conventions.md
+++ b/docs/development/database/conventions.md
@@ -5,7 +5,7 @@
 - [Table Naming](#table-naming)
 - [Model File Organization](#model-file-organization)
   - [Rule 1: One File Per Table](#rule-1-one-file-per-table)
-  - [Rule 2: Tightly Coupled 1:1 Tables](#rule-2-tightly-coupled-11-tables)
+  - [Rule 2: Tightly Coupled One-to-One Tables](#rule-2-tightly-coupled-one-to-one-tables)
   - [Rule 3: Association Tables](#rule-3-association-tables)
   - [Rule 4: Gray Areas](#rule-4-gray-areas)
   - [Revisiting the Rules](#revisiting-the-rules)
@@ -42,7 +42,7 @@ models/exercise_instance.py
 models/technique.py
 ```
 
-### Rule 2: Tightly Coupled 1:1 Tables
+### Rule 2: Tightly Coupled One-to-One Tables
 Tables with enforced 1:1 relationships that are always used together may be
 bundled in the same file.
 

--- a/docs/development/deprecation-warnings.md
+++ b/docs/development/deprecation-warnings.md
@@ -4,7 +4,6 @@
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
-- [Development cycle timing](#development-cycle-timing)
 - [Triage workflow](#triage-workflow)
 - [Dependency upgrade handling](#dependency-upgrade-handling)
 - [Warning suppression policy](#warning-suppression-policy)
@@ -53,7 +52,6 @@ After the upgrade process:
 
 New warnings may not surface during the upgrade test run, which is why the
 mid-cycle warning policy exists.
-
 
 ## Warning suppression policy
 - AI tooling must not suppress warnings by default.

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -21,7 +21,7 @@ Use before finalizing any response governed by the interaction contract.
 - Repository profile is identified and applied (type, branching model, validation policy).
 - If context-bootstrap was run, the next response begins with the Standards Snapshot block.
 - Preflight gate emitted before any file edit or git action (branch, issue, docs-only scope, validation policy).
-- For documentation repositories with no documented validation command, do not ask for validation; proceed with PR workflow.
+- For documentation repositories, markdownlint is required. Do not ask for additional validation unless the repository documents it.
 - No silent guessing of material facts.
 - Weak premises were challenged.
 - No unnecessary abstraction introduced.

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -9,6 +9,7 @@
 - [Formatting Conventions](#formatting-conventions)
 - [Links and References](#links-and-references)
 - [Code Blocks](#code-blocks)
+- [Validation](#validation)
 - [Maintenance](#maintenance)
 
 ## Purpose
@@ -54,6 +55,12 @@ explicitly state otherwise.
 - Use fenced code blocks with a language tag when possible.
 - Keep code examples minimal and focused on the rule being explained.
 - Do not include output that is environment-specific unless required.
+
+## Validation
+- All repositories must run markdownlint for documentation validation.
+- Markdownlint is the minimum baseline. Repositories may add additional checks.
+- Code repositories must document language-specific and repo-specific validation
+  commands in their repository standards.
 
 ## Maintenance
 - Update the Table of Contents when headings change.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [AI co-authors](#ai-co-authors)
 - [Repository profile](#repository-profile)
+- [Validation policy](#validation-policy)
 - [CI gates](#ci-gates)
 - [Local deviations](#local-deviations)
 
@@ -17,11 +18,15 @@
 - release_model: none
 - supported_release_lines: none
 
+## Validation policy
+- canonical_local_validation_command: scripts/lint/markdown-standards.sh
+- validation_required: yes (markdownlint required)
+
 ## CI gates
 Hard gates (required status checks on `develop`):
 - Standards compliance (`.github/workflows/standards-gates.yml`):
   - Repository profile validation (`scripts/lint/repo-profile.sh`)
-  - Markdown standards lint (`scripts/lint/markdown-standards.sh`)
+  - Markdownlint (`scripts/lint/markdown-standards.sh`)
   - Commit message lint (`scripts/lint/commit-messages.sh`)
   - Issue linkage validation (`scripts/lint/pr-issue-linkage.sh`)
 

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -19,6 +19,25 @@ if [[ ${#files[@]} -eq 0 ]]; then
   exit 2
 fi
 
+markdownlint_config=()
+if [[ -f ".markdownlint.yaml" ]]; then
+  markdownlint_config=(--config ".markdownlint.yaml")
+fi
+
+if command -v markdownlint >/dev/null 2>&1; then
+  markdownlint_cmd=(markdownlint)
+elif command -v npx >/dev/null 2>&1; then
+  markdownlint_cmd=(npx --yes markdownlint-cli)
+else
+  echo "ERROR: markdownlint not found. Install markdownlint-cli or ensure npx is available." >&2
+  exit 2
+fi
+
+markdownlint_failed=0
+if ! "${markdownlint_cmd[@]}" "${markdownlint_config[@]}" "${files[@]}"; then
+  markdownlint_failed=1
+fi
+
 failed=0
 
 for file in "${files[@]}"; do
@@ -75,4 +94,4 @@ for file in "${files[@]}"; do
 
 done
 
-exit $failed
+exit $((failed || markdownlint_failed))


### PR DESCRIPTION
# Pull Request

## Summary
- wire markdownlint into `scripts/lint/markdown-standards.sh` with a repo config
- document markdownlint as the baseline validation requirement
- align docs-only guidance with the new baseline

## Issue Linkage
- Fixes #109

## Testing
- scripts/lint/markdown-standards.sh

## Notes
- `.markdownlint.yaml` disables rules that conflict with existing docs so baseline enforcement can start immediately.
