### PR TITLE
chore: switch include directives to HTML comments

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,1 @@
 default: true
-# MD018 is incompatible with required #include directives in standards entry points.
-MD018: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,15 +1,3 @@
 default: true
-MD005: false
-MD007: false
+# MD018 is incompatible with required #include directives in standards entry points.
 MD018: false
-MD022: false
-MD031: false
-MD032: false
-MD037: false
-MD013: false
-MD024: false
-MD026: false
-MD033: false
-MD034: false
-MD040: false
-MD060: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Standards and Conventions - Agent Instructions
 
-#include docs/standards-and-conventions.md
-#include ./docs/repository-standards.md
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: ./docs/repository-standards.md -->
 
 ## User Overrides (Optional)
 

--- a/README.md
+++ b/README.md
@@ -6,23 +6,27 @@ documentation, repository structure, code management, and development practices,
 with per-repository overrides captured locally when needed.
 
 ## Table of Contents
+
 - [Scope](#scope)
 - [How to use](#how-to-use)
 - [Key documents](#key-documents)
 - [Status](#status)
 
 ## Scope
+
 - README and agent guidance
 - Repository structure and documentation patterns
 - Code management (Git) standards
 - Development standards by language/tooling
 
 ## How to use
+
 - Treat these documents as the default for new and existing repos.
 - Prefer linking to these standards from local repositories.
 - Capture exceptions locally with clear rationale.
 
 ## Key documents
+
 - Agent guidance: `AGENTS.md`
 - Markdown standards: `docs/foundation/markdown-standards.md`
 - Architecture standards: `docs/foundation/architecture-standards.md`
@@ -37,4 +41,5 @@ with per-repository overrides captured locally when needed.
 - Python standards overview: `docs/development/python/overview.md`
 
 ## Status
+
 Bootstrapping in progress; content will be layered in the order listed above.

--- a/docs/code-management/application-versioning-scheme.md
+++ b/docs/code-management/application-versioning-scheme.md
@@ -1,6 +1,7 @@
 # Application Versioning Scheme
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Operating model](#operating-model)
@@ -14,10 +15,12 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Ensure every deployed application artifact has a unique, human-readable version
 identifier that is stable, auditable, and compatible with release governance.
 
 ## Scope
+
 This scheme applies to applications that run a single active instance in
 production and follow linear promotion across environments.
 
@@ -25,11 +28,13 @@ It does not define versioning for shared libraries or multi-active deployment
 models.
 
 ## Operating model
+
 - Each environment runs exactly one application version at a time.
 - Promotion is linear from develop to release to production.
 - Version identifiers must be sufficient to answer, "What is running now?"
 
 ## Invariants
+
 - Every deployed artifact maps to a unique version string.
 - The base version (`MAJOR.MINOR.PATCH`) is stored in a manifest and changes
   only via pull request.
@@ -41,18 +46,21 @@ models.
 - The scheme avoids implicit state and hidden counters in source control.
 
 ## Version format
+
 Use a four-part numeric version string:
 
-```
+```text
 MAJOR.MINOR.PATCH.BUILD
 ```
 
 Rules:
+
 - Each component is a non-negative integer with no leading zeros (except `0`).
 - `BUILD` is the rightmost component and is computed at build time.
 - No suffixes or build metadata are used in the version string.
 
 ## Source of truth
+
 - The canonical base version (`MAJOR.MINOR.PATCH`) lives in a single build or
   package manifest.
 - The full runtime version string (`MAJOR.MINOR.PATCH.BUILD`) is derived at
@@ -61,6 +69,7 @@ Rules:
   version; do not duplicate it in code.
 
 ## Increment rules
+
 - `PATCH` increments by exactly 1 when a promotion to the release branch opens
   and starts a new development cycle.
 - `MAJOR` and `MINOR` changes reset `PATCH` to `0` and restart the build
@@ -71,15 +80,18 @@ Rules:
   are explicitly designated as version-bump work.
 
 ## Build derivation
+
 `BUILD` is derived from git history and does not live in source control.
 
 Recommended algorithm:
+
 1. Read the base version from the manifest (`MAJOR.MINOR.PATCH`).
 2. Find the commit that introduced that base version.
 3. Set `BUILD` to the number of commits since that commit on the current
    branch.
 
 Release tagging:
+
 - Tag release bases as `vMAJOR.MINOR.PATCH` when promoting to the release
   branch.
 - CI pipelines should fetch full history (`fetch-depth: 0`) so the build
@@ -89,6 +101,7 @@ If the base version commit cannot be found (for example, shallow history),
 fail the build rather than guessing.
 
 ## Promotion workflow
+
 1. Create a promotion branch from develop and open a pull request to the
    release branch.
 2. If the release branch has diverged, merge release into the promotion branch
@@ -100,7 +113,9 @@ fail the build rather than guessing.
 6. Promote release to production with no additional version changes.
 
 ## Validation and failure modes
+
 CI must fail when:
+
 - The base version string does not match `MAJOR.MINOR.PATCH`.
 - The derived build number cannot be computed deterministically.
 - `PATCH` bump pull requests do not increment `PATCH` by exactly 1.
@@ -109,5 +124,6 @@ CI must fail when:
 Violations are fatal exceptions that block merges, releases, and deployments.
 
 ## Related documents
+
 - Release and versioning policy: [release-versioning.md](release-versioning.md)
 - Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)

--- a/docs/code-management/branching-and-deployment.md
+++ b/docs/code-management/branching-and-deployment.md
@@ -1,6 +1,7 @@
 # Branching and Deployment Model
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Scope](#2-scope)
@@ -19,14 +20,17 @@
 - [9. Guiding Principle](#9-guiding-principle)
 
 ## Status
+
 Active v0.2
 
 ---
 
 ## 1. Purpose
+
 Define the branching model and deployment semantics for application repositories.
 
 Goals:
+
 - clear, boring, survivable workflows
 - deterministic promotion across environments
 - minimal cognitive overhead for future contributors
@@ -35,6 +39,7 @@ Goals:
 ---
 
 ## 2. Scope
+
 Applies to application repositories with environment-based deployments and
 linear promotion.
 
@@ -50,6 +55,7 @@ Repository type definitions live in
 [repository-types-and-attributes.md](repository-types-and-attributes.md).
 
 ## 3. Core Invariants
+
 1. Each long-lived branch maps to exactly one deployment environment.
 2. Promotion is monotonic: development to test to production.
 3. Humans decide merges; automation performs deployments.
@@ -59,13 +65,16 @@ Repository type definitions live in
 ---
 
 ## 4. Deployment Environments
+
 There are exactly four environments:
+
 - sandbox
 - development
 - test
 - production
 
 Each environment consists of:
+
 - one database
 - one API
 - one running application version
@@ -80,23 +89,26 @@ at v0.1.
 ---
 
 ## 5. Eternal Branches
+
 The following branches always exist and are protected:
+
 - develop
 - release
 - main
 
-| Branch  | Purpose                       | Deployment Target |
-|---------|-------------------------------|-------------------|
-| develop | Integration and rapid iteration | development     |
-| release | Qualification and validation  | test              |
-| main    | Production truth              | production        |
+| Branch  | Purpose                         | Deployment Target |
+|---------|---------------------------------|-------------------|
+| develop | Integration and rapid iteration | development       |
+| release | Qualification and validation    | test              |
+| main    | Production truth                | production        |
 
 ### Pull Request Requirement
+
 All eternal branches require pull requests for changes. Direct pushes to
 develop, release, or main are forbidden.
 
-- Changes to develop: create a feature/* or bugfix/* branch, then open a PR to
-  develop.
+- Changes to develop: create a `feature/*` or `bugfix/*` branch, then open a PR
+  to develop.
 - Changes to release: create a PR from a promotion branch to release.
 - Changes to main: create a PR from a promotion branch to main.
 - Exception: hotfix/* branches follow special forward-merge rules (see
@@ -108,12 +120,15 @@ corresponding environment where automation exists.
 ---
 
 ## 6. Short-Lived Branches
+
 All work occurs in short-lived branches.
 
 ### Branch Naming Conventions
+
 This prefix list applies to application repositories only.
 
 Only the following branch prefixes are allowed:
+
 - feature/*
 - bugfix/*
 - hotfix/*
@@ -122,7 +137,9 @@ Only the following branch prefixes are allowed:
 No other prefixes are permitted. When in doubt, use feature/*.
 
 ### feature/*
+
 Use for:
+
 - new functionality or features
 - structural changes or refactoring
 - documentation updates
@@ -131,28 +148,35 @@ Use for:
 - any work that is not a bug fix
 
 Rules:
+
 - branched from develop
 - merged into develop via pull request
 - deleted immediately after merge
 
 ### bugfix/*
+
 Use for:
+
 - non-urgent defect fixes discovered in development or test environments
 - fixes that do not block production
 
 Rules:
+
 - same as feature/*
 - branched from develop
 - merged into develop via pull request
 - deleted immediately after merge
 
 ### hotfix/*
+
 Use for:
+
 - production-blocking issues only
 - critical defects affecting live users
 - security vulnerabilities in production
 
 Rules:
+
 - branched from main
 - merged into main via pull request
 - immediately forward-merged into release and develop
@@ -162,36 +186,44 @@ Creation of a hotfix branch is an explicit admission of upstream process
 failure.
 
 ### promotion/*
+
 Use for:
+
 - controlled promotion between eternal branches
 - release qualification or production promotion
 
 Rules:
+
 - branched from the source eternal branch
 - merged only into the target eternal branch
 - deleted immediately after merge
 - required for normal promotions to release and main
 
 Naming:
+
 - `promotion/release-<version>-<yyyymmddhhmmss>` for develop to release
 - `promotion/main-<version>-<yyyymmddhhmmss>` for release to main
 
 ---
 
 ## 7. Promotion Flow
+
 Normal flow:
 
-feature/* or bugfix/* -> develop -> release -> main
+feature/*or bugfix/* -> develop -> release -> main
 
 Promotion semantics:
+
 - develop to release: candidate release, aggressive testing
 - release to main: production-ready, ship
 
 ---
 
 ## 8. Forbidden Operations
+
 The following are explicitly disallowed:
-- merging feature/* or bugfix/* directly into release or main
+
+- merging feature/*or bugfix/* directly into release or main
 - direct commits to eternal branches
 - direct pushes to develop, release, or main
 - cherry-picking between eternal branches
@@ -202,4 +234,5 @@ The following are explicitly disallowed:
 ---
 
 ## 9. Guiding Principle
+
 Boring workflows that never surprise are a competitive advantage.

--- a/docs/code-management/commit-messages-and-authorship.md
+++ b/docs/code-management/commit-messages-and-authorship.md
@@ -1,6 +1,7 @@
 # Commit Messages and Authorship
 
 ## Table of Contents
+
 - [Commit Message Format](#commit-message-format)
 - [Types](#types)
 - [Example](#example)
@@ -14,9 +15,10 @@
 - [Project-specific AI identities](#project-specific-ai-identities)
 
 ## Commit Message Format
+
 Follow Conventional Commits:
 
-```
+```text
 <type>: <short description>
 
 <optional detailed description>
@@ -25,6 +27,7 @@ Follow Conventional Commits:
 ```
 
 ## Types
+
 - feat
 - fix
 - docs
@@ -34,7 +37,8 @@ Follow Conventional Commits:
 - chore
 
 ## Example
-```
+
+```text
 fix: update API routers for renamed terminology
 
 Updated API routers and schemas to use the new naming convention.
@@ -44,21 +48,25 @@ Co-Authored-By: ai-tool <id+ai-tool@users.noreply.github.com>
 ```
 
 ## Commit Authorship
+
 All commits must be authored by a human. The human owns responsibility and
 accountability for the change.
 
 Do not set AI tooling as the author or committer.
 
 ## AI Co-Authorship
+
 If an AI tool materially contributed to the change, include a co-author trailer
 for that tool.
 
 If no AI tool contributed, omit AI co-authors.
 
 ## AI identity strategy
+
 AI service accounts represent tools, not humans.
 
 Default naming:
+
 - Personal scope: `<owner>-<tool>` (for example, `wphillipmoore-codex`)
 - Project scope: `<project>-<tool>` (for example, `mnemosys-codex`)
 - Shared or org scope: `<org>-<tool>` or `ai-<tool>` when multiple humans share
@@ -69,10 +77,12 @@ All repositories must list approved AI identities in
 commit trailers.
 
 ## Adding a New AI Service Account
+
 When onboarding a new AI tool, create a dedicated service account to preserve
 clear attribution.
 
 ### Step-by-step checklist
+
 1. Sign out of GitHub or use a private browsing session so the new account is
    created separately.
 2. Create a GitHub account with the chosen name (per AI identity strategy).
@@ -88,7 +98,9 @@ Then update the repository-specific AI co-author list in
 `docs/standards-and-conventions.md`.
 
 ### Practical example: wphillipmoore-codex
+
 Create the account:
+
 1. Username: `wphillipmoore-codex`
 2. Signup email: `w.phillip.moore+github-codex@gmail.com`
 3. Verify the email after signup.
@@ -98,7 +110,9 @@ Create the account:
    - `255923655+wphillipmoore-codex@users.noreply.github.com`
 
 ### Practical example: wphillipmoore-claude
+
 Create the account:
+
 1. Username: `wphillipmoore-claude`
 2. Signup email: `w.phillip.moore+github-claude@gmail.com`
 3. Verify the email after signup.
@@ -108,7 +122,9 @@ Create the account:
    - `255925739+wphillipmoore-claude@users.noreply.github.com`
 
 ## Scaling to shared ownership
+
 When multiple humans share responsibility:
+
 - Prefer shared tool identities (`<org>-<tool>` or `ai-<tool>`) over
   person-scoped accounts.
 - Keep the human as the commit author; add the AI tool as a co-author.
@@ -118,6 +134,7 @@ When multiple humans share responsibility:
   an organization.
 
 ## Project-specific AI identities
+
 Maintain approved AI co-author identities in
 `docs/standards-and-conventions.md` for each repository. Use only the identities
 listed there when adding co-author trailers.

--- a/docs/code-management/documentation-branching-model.md
+++ b/docs/code-management/documentation-branching-model.md
@@ -1,6 +1,7 @@
 # Documentation Branching Model
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Scope](#2-scope)
@@ -15,19 +16,23 @@
 - [8. Related documents](#8-related-documents)
 
 ## Status
+
 Active v0.2
 
 ---
 
 ## 1. Purpose
+
 Define a minimal branching model for documentation repositories that keeps the
 workflow simple and durable.
 
 ## 2. Scope
+
 Applies to repositories that contain documentation, templates, or example
 snippets only and do not publish deployable artifacts.
 
 ## 3. Core invariants
+
 - `develop` is the single eternal branch.
 - `main` is not used for documentation repositories.
 - All changes arrive via short-lived branches.
@@ -37,42 +42,53 @@ snippets only and do not publish deployable artifacts.
 ## 4. Branch roles
 
 ### develop
+
 - default branch for documentation
 - source of published GitHub content
 - integration and release branch when a single branch is used
 
 ## 5. Short-lived branches
+
 Use short-lived branches for all changes.
 
 ### feature/*
+
 Use for:
+
 - new documentation or structure
 - refactors, reorganizations, or template updates
 
 Rules:
+
 - branched from `develop`
 - merged into `develop`
 - deleted after merge
 
 ### bugfix/*
+
 Use for:
+
 - corrections, clarifications, or small fixes
 
 Rules:
+
 - branched from `develop`
 - merged into `develop`
 - deleted after merge
 
 ## 6. Validation expectations
+
 Documentation repositories must run markdownlint for documentation validation.
 Automated test or release validation is not required. Additional validation is
 optional unless a specific repository documents a requirement.
 
 ## 7. Forbidden operations
+
 - direct commits to `develop`
 - long-lived branches other than `develop`
 - adding release branches or promotion flows without updating standards
 
 ## 8. Related documents
+
 - Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)

--- a/docs/code-management/github-issues.md
+++ b/docs/code-management/github-issues.md
@@ -1,6 +1,7 @@
 # GitHub Issue Standards
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
@@ -13,39 +14,47 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define a consistent, enforced workflow for GitHub issues so all changes are
 tracked, reviewable, and auditable.
 
 ## Scope
+
 Applies to all repositories that use GitHub issues and pull requests.
 
 ## Definitions
+
 - Issue: The unit of tracked work in GitHub.
 - Primary issue: The single issue a pull request is intended to close.
 - Sub-issue: A scoped unit of work that contributes to a parent issue but does
   not complete it.
 
 ## Core rules
+
 - Every pull request must have a primary GitHub issue. No exceptions.
 - Work must not begin until the issue exists.
 - One primary issue per pull request. If a PR must close multiple issues,
   document why in the PR description.
 
 ## Acceptance criteria
+
 Every issue must specify acceptance criteria if they are not intuitively
 obvious. If acceptance criteria are ambiguous, get explicit human confirmation
 before proceeding.
 
 Examples:
+
 - Docs-only issues: satisfied when documentation changes are merged.
 - Bug reports: may require reporter confirmation or verified reproduction and
   resolution steps.
 
 ## Issue templates
+
 Repositories must use GitHub Issue Forms and disable blank issues so all issues
 capture the required structure.
 
 Minimum required fields:
+
 - Summary
 - Problem or goal
 - Acceptance criteria
@@ -54,10 +63,12 @@ Minimum required fields:
 - Validation or evidence
 
 Required configuration:
+
 - `.github/ISSUE_TEMPLATE/issue.yml` (or equivalent form name)
 - `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`
 
 ## Issue creation and linking
+
 - If a human already specified an issue, use it as the primary issue.
 - If no issue exists, create one before creating a branch or changing files.
 - If no issue exists, create it immediately using best-effort assumptions and
@@ -71,17 +82,21 @@ Required configuration:
   description and close the issue only when the criteria are satisfied.
 
 ## Sub-issues
+
 Create a sub-issue when:
+
 - the parent issue is too large for a single PR
 - the PR will not fully resolve the parent issue
 - the work can be reviewed and merged independently
 
 Sub-issue rules:
+
 - Link each sub-issue to its parent (task list or issue relationship).
 - The PR should close the sub-issue, not the parent, unless the PR completes
   the parent’s full scope.
 
 ## Closing behavior
+
 - Default: auto-close issues via PR closing keywords.
 - If acceptance criteria are specified, do not auto-close. The agent
   finalizing the PR is responsible for determining closure once the criteria
@@ -92,5 +107,6 @@ Sub-issue rules:
   issue open or create a follow-up issue and link it explicitly.
 
 ## Related documents
+
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)
 - Branching and deployment model: [branching-and-deployment.md](branching-and-deployment.md)

--- a/docs/code-management/hotfix-policy.md
+++ b/docs/code-management/hotfix-policy.md
@@ -1,6 +1,7 @@
 # Hotfix Policy
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Definition](#2-definition)
@@ -12,11 +13,13 @@
 - [8. Guiding Principle](#8-guiding-principle)
 
 ## Status
+
 Frozen v0.1 snapshot
 
 ---
 
 ## 1. Purpose
+
 Define the hotfix process as a controlled failure mode.
 
 Hotfixes exist to correct production-blocking issues when normal promotion flow
@@ -25,7 +28,9 @@ is insufficient. They are expected to be rare.
 ---
 
 ## 2. Definition
+
 A hotfix is a change that:
+
 - addresses a production outage or critical defect
 - cannot wait for standard develop to release to main promotion
 - requires immediate correction in production
@@ -33,13 +38,15 @@ A hotfix is a change that:
 ---
 
 ## 3. Branching Rules
+
 Hotfixes use the following branch namespace:
 
-```
+```text
 hotfix/<concise-description>
 ```
 
 Rules:
+
 - branch from main
 - fix only the production issue
 - no unrelated refactors or enhancements
@@ -47,7 +54,9 @@ Rules:
 ---
 
 ## 4. Merge Requirements
+
 A hotfix branch must:
+
 1. be merged into main
 2. be forward-merged into release
 3. be forward-merged into develop
@@ -59,9 +68,11 @@ Skipping any step is forbidden.
 ---
 
 ## 5. Cultural Invariant
+
 Creating a hotfix is an explicit signal of process failure upstream.
 
 The system is intentionally designed to make hotfixes:
+
 - visible
 - slightly painful
 - operationally expensive
@@ -71,7 +82,9 @@ This discourages normalization.
 ---
 
 ## 6. Postmortem Requirement
+
 Every hotfix requires a brief written postmortem addressing:
+
 - root cause
 - why the issue escaped test
 - what process change prevents recurrence
@@ -81,6 +94,7 @@ No blame. Only system correction.
 ---
 
 ## 7. Forbidden Practices
+
 - using hotfixes for convenience
 - long-lived hotfix branches
 - bypassing release validation post-hotfix
@@ -89,4 +103,5 @@ No blame. Only system correction.
 ---
 
 ## 8. Guiding Principle
+
 Hotfixes are allowed, not accepted.

--- a/docs/code-management/library-branching-and-release.md
+++ b/docs/code-management/library-branching-and-release.md
@@ -1,6 +1,7 @@
 # Library Branching and Release Model
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Scope](#2-scope)
@@ -19,20 +20,24 @@
 - [10. Related documents](#10-related-documents)
 
 ## Status
+
 Active v0.2
 
 ---
 
 ## 1. Purpose
+
 Define a branching model for libraries that supports multiple concurrent
 release lines and predictable publishing.
 
 ## 2. Scope
+
 Applies to library repositories that publish reusable artifacts (via a package
 registry or tagged automation) and are not deployed to environment-bound
 infrastructure.
 
 ## 3. Core invariants
+
 - `develop` is the integration branch.
 - `main` is not used for library repositories.
 - Stable releases are tagged and published from release branches.
@@ -43,61 +48,77 @@ infrastructure.
 ## 4. Branch roles
 
 ### develop
+
 - default branch for active development
 - entry point for all code changes
 
 ### release branches
+
 Long-lived branches for supported release lines.
 
 Naming:
+
 - `release/<major>.<minor>.x`
 
 Rules:
+
 - patch-only changes
 - no new features
 - no merges from `develop`
 - no merges from other release branches
 
 Support policy:
+
 - default target is the current and previous `MAJOR.MINOR` lines
 - repositories may expand or contract support by updating the repository profile
 
 ## 5. Short-lived branches
+
 All work occurs in short-lived branches that merge into `develop` or a release
 branch.
 
 ### feature/*
+
 Use for:
+
 - new functionality or features
 - refactoring or structural changes
 - documentation updates
 
 Rules:
+
 - branched from `develop`
 - merged into `develop`
 - deleted after merge
 
 ### bugfix/*
+
 Use for:
+
 - non-urgent defect fixes for current development
 - patch releases on a release branch
 
 Rules:
+
 - branched from `develop` or the target release branch
 - merged into the branch it was created from
 - deleted after merge
 
 ### hotfix/*
+
 Use for:
+
 - urgent defects affecting released versions
 
 Rules:
+
 - branched from the affected release branch
 - merged into that release branch
 - backported to `develop`
 - deleted after merge
 
 ## 6. Release workflow
+
 - `MAJOR` and `MINOR` releases are cut from a new release branch created from
   `develop`.
 - Tag releases on the relevant release branch.
@@ -105,17 +126,20 @@ Rules:
 - Every release is tagged and published as an immutable artifact.
 
 ## 7. Pre-release policy
+
 - Pre-releases are allowed for validation and early adopters.
 - Pre-releases are tagged and published with pre-release identifiers defined by
   the library versioning scheme or the target ecosystem.
 - Pre-releases never replace or mutate stable releases.
 
 ## 8. Backporting policy
+
 - Backports are explicit and documented in the pull request.
 - Use cherry-picks or equivalent to avoid feature drift.
 - If a change cannot be safely backported, document the rationale.
 
 ## 9. Forbidden operations
+
 - direct commits to `develop`
 - direct commits to release branches
 - merging `develop` into release branches
@@ -123,6 +147,7 @@ Rules:
 - publishing artifacts without a matching source tag
 
 ## 10. Related documents
+
 - Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
 - Release and versioning policy: [release-versioning.md](release-versioning.md)
 - Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)

--- a/docs/code-management/library-versioning-scheme.md
+++ b/docs/code-management/library-versioning-scheme.md
@@ -1,6 +1,7 @@
 # Library Versioning Scheme
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Invariants](#invariants)
@@ -13,28 +14,33 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define how supporting libraries are versioned, released, and consumed.
 
 ## Scope
+
 This scheme applies to internal and external libraries used by applications.
 If the target ecosystem mandates a specific versioning format, that format
 supersedes the default scheme below (for example, Python packages follow
 PEP 440).
 
 ## Invariants
+
 - Every released library artifact maps to a unique version string.
 - Version numbers are never reused or mutated after release.
 - Releases are immutable and reproducible from source.
 - Compatibility expectations are explicit and tied to the version number.
 
 ## Version format
+
 Default: Semantic Versioning
 
-```
+```text
 MAJOR.MINOR.PATCH
 ```
 
 Rules:
+
 - Each component is a non-negative integer with no leading zeros (except `0`).
 - Stable releases do not use suffixes or build metadata.
 - Pre-release identifiers are allowed only for pre-release artifacts and must
@@ -43,6 +49,7 @@ Rules:
   by the ecosystem or explicitly documented.
 
 ## Source of truth
+
 - The canonical version string lives in a single build or package manifest.
 - All other references must derive from that value; do not duplicate it in code.
 - Runtime reads should use package metadata rather than hard-coded strings.
@@ -50,6 +57,7 @@ Rules:
   segments or build metadata unless the ecosystem requires them.
 
 ## Increment rules
+
 - `MAJOR` increments for breaking API or behavioral changes.
 - `MINOR` increments for backward-compatible features or expansions.
 - `PATCH` increments for backward-compatible bug fixes.
@@ -59,12 +67,14 @@ Rules:
   waive compatibility discipline.
 
 ## Release workflow
+
 1. Assign a version at release time and tag it in source control.
 2. Build and publish an immutable artifact for that version.
 3. Ensure the released artifact matches the tagged source exactly.
 4. Produce release notes that describe compatibility impact.
 
 ## Dependency management
+
 - Applications and libraries must consume explicit version ranges that encode
   compatibility expectations.
 - Production builds must pin exact versions via lockfiles or equivalent
@@ -72,7 +82,9 @@ Rules:
 - Upgrades are deliberate changes, not background drift.
 
 ## Validation and failure modes
+
 CI must fail when:
+
 - The version string does not match the required format.
 - A version number is reused or regresses.
 - A release is attempted from untagged or dirty source.
@@ -81,6 +93,7 @@ CI must fail when:
 Violations are fatal exceptions that block publishing and consumption.
 
 ## Related documents
+
 - Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Release and versioning policy: [release-versioning.md](release-versioning.md)

--- a/docs/code-management/overview.md
+++ b/docs/code-management/overview.md
@@ -1,19 +1,23 @@
 # Code Management Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Document Map](#document-map)
 
 ## Purpose
+
 Define reusable standards for source control, branching, releases, and pull
 request workflows that emphasize durability and clarity.
 
 ## Scope
+
 These standards apply to code management across repositories. Language- or
 tool-specific requirements belong in development standards.
 
 ## Document Map
+
 - Source control guidelines: [source-control-guidelines.md](source-control-guidelines.md)
 - Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
 - Branching and deployment: [branching-and-deployment.md](branching-and-deployment.md)

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -51,9 +51,9 @@ Every pull request must have a primary GitHub issue. If no issue exists,
 create one before creating a branch or changing files.
 
 If the issue has no special acceptance criteria, include a closing keyword in
-the PR description so the issue auto-closes on merge (for example, `Fixes
-#123`). If acceptance criteria exist, use a non-closing reference and close
-the issue only after the criteria are satisfied. See
+the PR description so the issue auto-closes on merge (for example,
+`Fixes #123`). If acceptance criteria exist, use a non-closing reference and
+close the issue only after the criteria are satisfied. See
 [GitHub Issue Standards](github-issues.md) for acceptance criteria rules and
 sub-issue guidance.
 

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -1,6 +1,7 @@
 # Pull Request Workflow
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Docs-Only Exception](#docs-only-exception)
 - [Issue linkage](#issue-linkage)
@@ -14,6 +15,7 @@
 - [Pull Request Finalization](#pull-request-finalization)
 
 ## Purpose
+
 Pull requests must pass all hard-gate automated checks before submission. CI
 is a backstop, not a substitute for developer diligence. See
 [CI gates](source-control-guidelines.md#ci-gates) for hard versus soft gate
@@ -23,6 +25,7 @@ Submitting failing PRs wastes reviewer time, pollutes history, and undermines
 confidence in the codebase.
 
 ## Docs-Only Exception
+
 Documentation-only changes may skip the unit test suite and coverage checks
 when the diff includes only documentation files.
 
@@ -43,6 +46,7 @@ Markdownlint and any docs-only validation commands must still run even when
 tests are skipped.
 
 ## Issue linkage
+
 Every pull request must have a primary GitHub issue. If no issue exists,
 create one before creating a branch or changing files.
 
@@ -54,12 +58,13 @@ the issue only after the criteria are satisfied. See
 sub-issue guidance.
 
 ## Pull request template
+
 Every repository must install a pull request template at
 `.github/pull_request_template.md` and keep it aligned with local workflow.
 
 Minimum required template:
 
-```
+```text
 # Pull Request
 
 ## Summary
@@ -84,8 +89,10 @@ The template must list markdownlint and any additional required validation
 commands in the Testing section.
 
 ## Pre-Submission Requirements
+
 Before creating a pull request, all of the following must be met unless the
 docs-only exception applies:
+
 1. 100 percent unit test success
 2. Coverage must not decline (lines and branches)
 3. All hard-gate code quality checks must pass
@@ -96,9 +103,11 @@ Markdownlint is required for all repositories and must be part of the
 pre-submission run. Additional commands are required when documented.
 
 ## Pre-Submission Checklist
+
 Use the repository's canonical validation command(s) when available.
 
 If no single command exists, run:
+
 - markdownlint
 - full test suite
 - linting
@@ -109,14 +118,17 @@ Do not run only a subset of tests. Local validation should mirror CI hard
 gates. Run soft-gate checks when documented.
 
 ## Pull request submission
+
 Use the GitHub CLI for PR creation unless a repository documents an alternative.
 
 Required sequence:
+
 1. Ensure the feature branch exists locally and all commits are present.
 2. Push the branch to the remote before creating the PR.
 3. Create the PR only after the remote branch exists.
 
 Recommended commands:
+
 ```bash
 git status -sb
 git push -u origin <feature-branch>
@@ -124,10 +136,15 @@ gh pr create --base <target-branch> --head <feature-branch>
 ```
 
 Failure mode and fix:
-- If PR creation fails because the head or base SHA is blank or the head ref is not a branch, the branch is not pushed. Push the branch to the remote and retry the PR creation command.
+
+- If PR creation fails because the head or base SHA is blank or the head ref is
+  not a branch, the branch is not pushed. Push the branch to the remote and
+  retry the PR creation command.
 
 ## What to Do When Checks Fail
+
 If any hard-gate check fails:
+
 1. do not create the PR
 2. fix the failing tests or checks
 3. re-run the full checklist
@@ -137,11 +154,13 @@ If a soft-gate check fails, either fix it immediately or document the failure
 with rationale and follow-up tracking before submission.
 
 Common mistakes to avoid:
+
 - "I only changed one area, so I only ran those tests"
 - "The test failures are pre-existing"
 - "I will fix it in a follow-up PR"
 
 ## Auto-merge policy
+
 Auto-merge is the default for all pull requests, including docs-only changes.
 
 Opt out when a merge must be scheduled or reviewed by adding the label
@@ -161,6 +180,7 @@ wait for required checks to complete. If any required check fails, fix the
 issue immediately and re-run the checks before merging.
 
 ## Async finalization guardrail
+
 Async submission requires a follow-up finalize step. To prevent "pending
 finalization" work from being forgotten, apply the following guardrail at the
 start of each work session or before declaring a development cycle complete:
@@ -174,12 +194,14 @@ Do not declare a development cycle complete while open PRs remain against
 `develop`.
 
 ## Pull Request Finalization
+
 Finalization begins only after all required CI gates have completed
 successfully and the PR is ready to merge (manually or via auto-merge). If a
 required check fails, resolve it immediately and re-run the checks before
 merging.
 
 Finalize the PR in this order:
+
 1. merge the PR and delete the remote branch (or wait for auto-merge to do so)
 2. update local copy of the target branch
 3. synchronize the local environment with dependency specifications

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -1,6 +1,7 @@
 # Release and Versioning Policy
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Release Definition](#2-release-definition)
@@ -16,14 +17,17 @@
 - [9. Guiding Principle](#9-guiding-principle)
 
 ## Status
+
 Active v0.2
 
 ---
 
 ## 1. Purpose
+
 Define how components are versioned, released, and consumed.
 
 Goals:
+
 - deterministic builds
 - reproducible deployments
 - clean rollback semantics
@@ -32,7 +36,9 @@ Goals:
 ---
 
 ## 2. Release Definition
+
 A release is defined as:
+
 - a versioned, immutable artifact
 - a matching source tag
 - suitable for deployment, distribution, and rollback
@@ -40,13 +46,17 @@ A release is defined as:
 Releases are not mutable.
 
 ### Application repositories
+
 For application repositories, a release is tied to promotion:
+
 - merge into the `release` or `main` branch
 - produce a versioned artifact for deployment
 - tag the release base as `vMAJOR.MINOR.PATCH`
 
 ### Library repositories
+
 For library repositories, a release is tied to publishing:
+
 - tag a version in source control
 - publish the artifact to the package registry when applicable
 - tagging alone is sufficient when distribution is via source control
@@ -55,18 +65,21 @@ For ecosystems with strict versioning (for example, PyPI), use the ecosystem
 format (PEP 440) and never attempt to republish the same version.
 
 ### Documentation repositories
+
 Documentation repositories do not require formal releases or version numbers.
 Git history and tags (when needed) are the source of truth.
 
 ---
 
 ## 3. Versioning
+
 - Use the applicable versioning scheme for the artifact type.
 - Base versions are assigned explicitly; build numbers are derived at build time
   for applications.
 - Version bumps are explicit and reviewed.
 
 Guideline:
+
 - Libraries: use the Library Versioning Scheme or the ecosystem's required
   versioning format.
 - Applications: use the Application Versioning Scheme
@@ -75,12 +88,15 @@ Guideline:
 ---
 
 ## 4. Pre-release policy
+
 - Pre-releases are allowed only when the target ecosystem supports them.
 - Pre-release artifacts must use explicit pre-release identifiers.
 - Pre-releases are never promoted or mutated into stable releases.
 
 ## 5. Artifact Properties
+
 Released artifacts must be:
+
 - immutable
 - content-addressable by version
 - consumable by the ecosystem's distribution mechanism
@@ -91,6 +107,7 @@ Artifacts are first-class operational objects.
 ---
 
 ## 6. Relationship to Branches
+
 - Application branches drive deployment automation.
 - Library releases are cut from release branches.
 - Artifacts provide audit, rollback, and traceability.
@@ -100,7 +117,9 @@ Operational truth is anchored in artifacts, not branch pointers.
 ---
 
 ## 7. Rollback Strategy
+
 Rollback is performed by:
+
 - redeploying a previously released version
 - never mutating or reusing version numbers
 
@@ -109,6 +128,7 @@ Rollbacks are operational decisions, not code changes.
 ---
 
 ## 8. Forbidden Practices
+
 - mutating released artifacts
 - reusing version numbers
 - deploying unreleased code
@@ -120,4 +140,5 @@ Violations are fatal exceptions that block merges, releases, and deployments.
 ---
 
 ## 9. Guiding Principle
+
 If you cannot precisely name what is running, you do not control it.

--- a/docs/code-management/repository-types-and-attributes.md
+++ b/docs/code-management/repository-types-and-attributes.md
@@ -1,6 +1,7 @@
 # Repository Types and Attributes
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Core concepts](#core-concepts)
@@ -14,13 +15,16 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define the repository classifications and metadata needed to select the correct
 branching, release, and versioning standards.
 
 ## Scope
+
 Applies to every repository using these standards.
 
 ## Core concepts
+
 - A repository type selects the default workflow rules.
 - Repository attributes document deviations or additional constraints.
 - When a repository does not fit an existing type, define a new type before
@@ -29,37 +33,48 @@ Applies to every repository using these standards.
 ## Repository types
 
 ### Application repositories
+
 An application repository:
+
 - deploys infrastructure-backed services or APIs
 - promotes linearly across environments
 - runs one active version per environment
 
 Use:
+
 - Branching and deployment model: [branching-and-deployment.md](branching-and-deployment.md)
 - Application versioning scheme: [application-versioning-scheme.md](application-versioning-scheme.md)
 
 ### Library repositories
+
 A library repository:
+
 - produces reusable artifacts published to a package registry or consumed via
   tagged distribution (for example, GitHub Actions)
 - has no environment-bound infrastructure
 - may support multiple concurrent release lines
 
 Use:
+
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Library versioning scheme: [library-versioning-scheme.md](library-versioning-scheme.md)
 
 ### Documentation repositories
+
 A documentation repository:
+
 - contains documentation, templates, or example snippets only
 - has no deployable application or package artifact
 - does not require formal releases or versioning
 
 Use:
+
 - Documentation branching model: [documentation-branching-model.md](documentation-branching-model.md)
 
 ## Required repository attributes
+
 Each repository must declare, at minimum:
+
 - `repository_type`: `application`, `library`, or `documentation`
 - `versioning_scheme`: `application`, `library`, `ecosystem-specific`, or `none`
 - `branching_model`: `application-promotion`, `library-release`, or `docs-single-branch`
@@ -68,15 +83,18 @@ Each repository must declare, at minimum:
   `MAJOR.MINOR` lines for libraries; `none` for documentation
 
 ## Declaration requirement
+
 Record repository type and attributes in the repository's
 `docs/standards-and-conventions.md` under the project-specific overlay.
 
 ## Change control
+
 Changing a repository type or its declared attributes is a governance change.
 Treat it as a deliberate migration with explicit review and updated standards
 references.
 
 ## Related documents
+
 - Branching and deployment model: [branching-and-deployment.md](branching-and-deployment.md)
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Documentation branching model: [documentation-branching-model.md](documentation-branching-model.md)

--- a/docs/code-management/shared-actions-library.md
+++ b/docs/code-management/shared-actions-library.md
@@ -1,6 +1,7 @@
 # Shared Actions Library
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Design principles](#design-principles)
@@ -13,14 +14,17 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define standards for a shared GitHub Actions library that provides reusable,
 versioned automation across repositories.
 
 ## Scope
+
 Applies to all repositories that consume shared automation for CI, validation,
 release, or pull request workflows.
 
 ## Design principles
+
 - Centralize action logic to reduce drift.
 - Keep workflows in product repositories minimal and declarative.
 - Prefer composite actions over per-repository scripts.
@@ -29,9 +33,10 @@ release, or pull request workflows.
 - Shared actions repositories follow the library branching model.
 
 ## Repository structure
+
 A shared actions repository must be organized by responsibility:
 
-```
+```text
 actions/
   <action-name>/
     action.yml
@@ -40,64 +45,78 @@ actions/
 ```
 
 Rules:
+
 - One action per directory.
 - Each action documents inputs, outputs, and example usage.
 - Scripts stay minimal and are colocated with the action.
 
 ## Action design rules
+
 - Actions must be deterministic and idempotent.
 - Inputs are explicit; avoid implicit environment inference.
 - Failures must be actionable and surface clear error messages.
 - Avoid tightly coupling actions to a single repository structure.
 
 ## Versioning and pinning
+
 - Version the repository with SemVer tags (for example, `v1`, `v1.2.0`).
 - Tags apply to the entire repository; there is no per-action tagging.
 - Repositories must reference actions by tag or commit SHA.
 - Never reference the default branch.
 
 ## Security and permissions
+
 - Actions must declare least-privilege permissions.
 - Avoid persistent credentials; prefer short-lived tokens when possible.
 - Document any required secrets and their scope.
 
 ## Adoption workflow
+
 1. Introduce actions in the shared library.
 2. Update standards to reference the shared library.
 3. Pilot in one repository and validate parity.
 4. Roll out incrementally across repositories.
 
 ## Implementation plan
+
 Phase 0: decisions
+
 - Choose repository name, visibility, and default branch (`develop`).
 - Select the initial versioning/tagging policy.
 
 Phase 1: bootstrap
+
 - Add `README.md`, `LICENSE`, and `SECURITY.md`.
 - Define repository layout under `actions/`.
 
 Phase 2: core actions
+
 - Validation action (tests, lint, type checking, coverage).
 - Dependency audit action.
 - Auto-merge action with a label-based opt-out.
 
 Phase 3: repository CI
+
 - Lint action metadata and scripts.
 - Validate workflow syntax.
 
 Phase 4: standards integration
+
 - Reference the shared actions library in code management standards.
 - Document the manual-merge opt-out label.
 
 Phase 5: pilot adoption
+
 - Replace in-repo workflow logic with shared actions in one repository.
 - Validate parity with existing CI gates.
 
 Phase 6: rollout
+
 - Apply shared actions to the remaining repositories in waves.
 - Keep changes small and reversible.
 
 ## Related documents
+
 - Library branching and release model: [library-branching-and-release.md](library-branching-and-release.md)
 - Source control guidelines: [source-control-guidelines.md](source-control-guidelines.md)
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -1,6 +1,7 @@
 # Source Code Management Guidelines
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. AI Assistance (Explicitly Bounded)](#1-ai-assistance-explicitly-bounded)
 - [2. Version Control Platform](#2-version-control-platform)
@@ -23,12 +24,15 @@
 - [7. Guiding Principle](#7-guiding-principle)
 
 ## Status
+
 Active v0.2
 
 ---
 
 ## 1. AI Assistance (Explicitly Bounded)
+
 Constraints:
+
 - AI-generated code must be reviewed with the same rigor as external
   contributions.
 - AI assistance must never become a silent dependency.
@@ -42,6 +46,7 @@ convenience.
 ---
 
 ## 2. Version Control Platform
+
 Git is the source control system.
 
 GitHub is the initial central repository host, including GitHub Actions for
@@ -50,7 +55,9 @@ CI/CD.
 This decision is explicitly provisional, not foundational.
 
 ### Lock-In Awareness
+
 GitHub-specific dependencies must be:
+
 - understood
 - tracked
 - periodically reassessed
@@ -65,7 +72,9 @@ Migration readiness is not required at v0.1, but migration awareness is.
 ## 3. Repository Strategy
 
 ### Core Philosophy
+
 Repositories should be:
+
 - small
 - modular
 - scoped to a single semantic responsibility
@@ -73,18 +82,22 @@ Repositories should be:
 Independent components should live in separate repositories by default.
 
 ### Boundary Rule
+
 Repository boundaries follow semantic ownership and lifecycle, not convenience.
 
 This improves:
+
 - independent evolution
 - reduced cognitive load
 - long-term maintainability
 - survivability without original authorship
 
 ### Explicit Non-Decision
+
 Monorepo vs. multirepo strategy is not locked at v0.1.
 
 This decision may be revisited once:
+
 - dependency graphs stabilize
 - tooling friction is observed
 - CI/CD cost and complexity are measurable
@@ -94,13 +107,16 @@ This decision may be revisited once:
 ## 4. Runtime Version Policy
 
 ### Supported Versions
+
 - The current stable language runtime version is the default target.
 - Additional versions must be explicitly listed and justified.
 
 ### CI Requirements
+
 CI pipelines must validate against the current stable runtime version.
 
 ### Deployment Rule
+
 Production deployments use the current stable runtime version.
 
 Invariant:
@@ -110,7 +126,9 @@ technical debt.
 ---
 
 ## 5. CI/CD Constraints
+
 CI/CD pipelines must be:
+
 - deterministic
 - stateless
 - reproducible locally
@@ -119,6 +137,7 @@ Automation should avoid reliance on opaque or irreducibly platform-specific
 behavior.
 
 CI configuration must remain:
+
 - readable
 - minimal
 - replaceable
@@ -131,6 +150,7 @@ Clever automation that cannot be reasonably expressed outside the current CI
 provider.
 
 ### CI gates
+
 Every CI check must be classified as either a hard gate or a soft gate.
 
 - Hard gate: blocking. A failing check prevents PR submission and merge.
@@ -147,6 +167,7 @@ Each repository must also document which hard gates apply per branch. Some
 hard gates may be develop-only, while others must run on all eternal branches.
 
 ### Docs-only CI skip policy
+
 Repositories must define a docs-only allowlist (for example, `docs/**`,
 `README.md`, and `CHANGELOG.md`). `.github/**` is not docs-only.
 
@@ -161,10 +182,12 @@ if a repository chooses to skip them, it must document the exception.
 Markdownlint and any docs-only validation commands must still run.
 
 ### Local enforcement hooks
+
 Use local Git hooks to fail closed on branch protection rules that should
 never be violated.
 
 Minimum requirement:
+
 - Install a `pre-commit` hook that blocks commits on protected branches
   (`develop`, `release`, `main`, and `release/*`).
 - Store hooks in-repo (for example, `scripts/git-hooks/`) and set
@@ -172,6 +195,7 @@ Minimum requirement:
 - Hooks must print a clear, actionable error and exit non-zero on violations.
 
 Example hook (store as `scripts/git-hooks/pre-commit` and mark executable):
+
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
@@ -180,8 +204,10 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 
 case "$branch" in
   develop|release|main|release/*)
-    echo "ERROR: direct commits to protected branches are forbidden ($branch)." >&2
-    echo "Create a short-lived branch (feature/* or bugfix/*) and open a PR." >&2
+    echo "ERROR: direct commits to protected branches are forbidden." >&2
+    echo "Branch: $branch" >&2
+    echo "Create a short-lived branch (feature/* or bugfix/*)" >&2
+    echo "and open a PR." >&2
     exit 1
     ;;
 esac
@@ -192,12 +218,14 @@ esac
 ## 6. Locked vs. Flexible Decisions
 
 ### Locked at v0.1
+
 - Git as the source control system
 - GitHub as the initial hosting provider
 - GitHub Actions for CI/CD
 - Runtime validation on the current stable version
 
 ### Explicitly Flexible
+
 - Repository granularity and structure
 - CI/CD provider choice
 - Deployment orchestration details
@@ -206,6 +234,7 @@ esac
 ---
 
 ## 7. Guiding Principle
+
 All source code management decisions are evaluated against a single overriding
 criterion:
 

--- a/docs/dependencies/dependency-update-workflow.md
+++ b/docs/dependencies/dependency-update-workflow.md
@@ -1,6 +1,7 @@
 # Dependency update workflow
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Sources of truth](#sources-of-truth)
@@ -10,15 +11,19 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define a repeatable, cross-ecosystem workflow for dependency updates that
 prioritizes stability, security, and auditability.
 
 ## Scope
+
 These rules apply to all dependencies, including application libraries,
 build tooling, CI/CD workflows, and deployment automation.
 
 ## Sources of truth
+
 Update dependencies at their source of truth:
+
 - language or platform manifests and lockfiles
 - CI/CD workflow definitions
 - dependency inventory or configuration files
@@ -26,6 +31,7 @@ Update dependencies at their source of truth:
 Regenerate any derived artifacts after updates.
 
 ## Workflow
+
 1. Collect update signals from:
    - dependency security alerts (for example, GitHub Security/Dependabot)
    - audit tooling (for example, language-specific vulnerability scanners)
@@ -36,7 +42,9 @@ Regenerate any derived artifacts after updates.
 5. Proceed through the standard pull request workflow.
 
 ## Failure handling
+
 If an attempted upgrade fails:
+
 1. Determine root cause before pinning.
 2. If the dependency itself is the blocker, create a tracking issue.
 3. Pin the dependency to the last known good version and document the pin at
@@ -44,10 +52,12 @@ If an attempted upgrade fails:
 4. Update any required anchor records or dependency history documentation.
 
 ## Release-cycle review
+
 For MAJOR and MINOR release cycles, review dependency security alerts and
 incorporate remediation into the dependency update process.
 
 ## Related documents
+
 - Python dependency management: [dependency-management.md](../development/python/dependency-management.md)
 - Dependency anchor records: [overview.md](overview.md)
 - Pull request workflow: [pull-request-workflow.md](../code-management/pull-request-workflow.md)

--- a/docs/dependencies/overview.md
+++ b/docs/dependencies/overview.md
@@ -1,6 +1,7 @@
 # Dependency Anchor Records
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Required layout](#required-layout)
@@ -9,21 +10,26 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Provide a durable record of why a dependency is anchored below the latest
 acceptable range, including the evidence from each failed upgrade attempt.
 
 ## Scope
+
 These records apply to any dependency that is pinned or constrained because
 newer releases fail validation or break compatibility.
 
 ## Required layout
+
 - Create one file per anchored dependency under `docs/dependencies/`.
 - Use the dependency name for the filename (`<dependency-name>.md`) and keep
   it stable across updates.
 - Each record must use the Markdown standards, including a Table of Contents.
 
 ## Record format
+
 Each dependency record must include, at minimum:
+
 - Summary of why the dependency is anchored.
 - Current constraint and the version range in effect.
 - Failure history with evidence for each failed upgrade attempt.
@@ -31,7 +37,7 @@ Each dependency record must include, at minimum:
 
 Suggested template:
 
-```
+```text
 # <Dependency name>
 
 ## Table of Contents
@@ -55,9 +61,11 @@ Define what will allow the anchor to be removed.
 ```
 
 ## Maintenance
+
 - Append new failure entries for each re-test; do not overwrite prior evidence.
 - Keep the record aligned with the current constraint and latest attempted
   version.
 
 ## Related documents
+
 - Dependency update workflow: [dependency-update-workflow.md](dependency-update-workflow.md)

--- a/docs/development/database/conventions.md
+++ b/docs/development/database/conventions.md
@@ -1,6 +1,7 @@
 # Database Conventions
 
 ## Table of Contents
+
 - [Schema design](#schema-design)
 - [Table Naming](#table-naming)
 - [Model File Organization](#model-file-organization)
@@ -11,6 +12,7 @@
   - [Revisiting the Rules](#revisiting-the-rules)
 
 ## Schema design
+
 - Prefer fully normalized schemas with first-class tables and typed columns.
 - JSON/JSONB is acceptable only when the data shape is unstable or evolving
   fast enough that normalization would churn.
@@ -18,22 +20,26 @@
   stabilizes.
 
 ## Table Naming
+
 Table names are singular, not plural.
 
 Rationale:
 A table name represents a single row, not a collection.
 
 Examples:
+
 - `user` (not `users`)
 - `exercise` (not `exercises`)
 - `practice_block` (not `practice_blocks`)
 
 ## Model File Organization
+
 File organization follows a multi-dimensional namespace (lifecycle coupling,
 conceptual domains, hierarchy) mapped onto a single filesystem. These rules
 minimize ambiguity while allowing explicit exceptions.
 
 ### Rule 1: One File Per Table
+
 Each database table gets its own model file named after the table.
 
 ```python
@@ -43,6 +49,7 @@ models/technique.py
 ```
 
 ### Rule 2: Tightly Coupled One-to-One Tables
+
 Tables with enforced 1:1 relationships that are always used together may be
 bundled in the same file.
 
@@ -58,6 +65,7 @@ class ExerciseLog(Base):
 ```
 
 ### Rule 3: Association Tables
+
 Many-to-many association tables are named alphanumerically and placed in the
 alphabetically first entity's file.
 
@@ -69,16 +77,20 @@ class ExerciseTechniqueAssociation(Base):
 This avoids subjective "importance" judgments and makes location predictable.
 
 ### Rule 4: Gray Areas
+
 Any case not covered by Rules 1-3 requires explicit discussion and a recorded
 decision. Document the rationale in code comments when non-obvious.
 
 Examples of gray areas:
+
 - polymorphic inheritance using joined-table patterns
 - 1:many relationships that are conceptually inseparable
 - legacy tables being deprecated together
 
 ### Revisiting the Rules
+
 Revisit these rules when:
+
 - a model file exceeds roughly 500 lines
 - contributors frequently jump between files that should be co-located
 - new contributors report confusion

--- a/docs/development/database/overview.md
+++ b/docs/development/database/overview.md
@@ -1,16 +1,20 @@
 # Database Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Document Map](#document-map)
 
 ## Purpose
+
 Define reusable database conventions that keep schemas and models consistent
 and discoverable.
 
 ## Scope
+
 These standards apply to relational schema naming and ORM model organization.
 
 ## Document Map
+
 - Database conventions: [conventions.md](conventions.md)

--- a/docs/development/deprecation-warnings.md
+++ b/docs/development/deprecation-warnings.md
@@ -1,6 +1,7 @@
 # Deprecation Warning Policy
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
@@ -11,14 +12,17 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define a consistent policy for triaging and resolving deprecation warnings so
 they do not accumulate silently or trigger ad hoc upgrades.
 
 ## Scope
+
 Applies to deprecation warnings emitted by runtimes, libraries, tooling, or
 frameworks during development, testing, or execution.
 
 ## Definitions
+
 - Deprecation warning: A notice that a behavior or API will be removed or
   changed in a future release.
 - Development cycle: Starts when a release is promoted to test and the
@@ -28,7 +32,9 @@ frameworks during development, testing, or execution.
   Developer, administrator, or operator warnings are not user-visible.
 
 ## Triage workflow
+
 When a deprecation warning is encountered:
+
 1. Search the project repository's GitHub issues for an existing issue that
    matches the warning text, warning code, and location.
 2. If an issue already exists and the warning is encountered mid-cycle, do not
@@ -44,9 +50,11 @@ When a deprecation warning is encountered:
    outcome; close it when the warning is resolved.
 
 ## Dependency upgrade handling
+
 Dependency upgrades must proceed independently of unresolved warnings.
 
 After the upgrade process:
+
 - Re-test existing warnings to confirm whether they still reproduce.
 - If a warning persists, attempt to resolve it using the triage workflow.
 
@@ -54,6 +62,7 @@ New warnings may not surface during the upgrade test run, which is why the
 mid-cycle warning policy exists.
 
 ## Warning suppression policy
+
 - AI tooling must not suppress warnings by default.
 - If a warning is user-visible and deferred, suppress it to avoid exposing
   end users to internal warnings.
@@ -62,9 +71,10 @@ mid-cycle warning policy exists.
   warning is resolved.
 
 ## Issue template
+
 Use a consistent issue template so warnings are searchable and comparable.
 
-```
+```text
 Title: Deprecation: <dependency or component> - <short description>
 
 Warning text:
@@ -105,5 +115,6 @@ Suppression (if any):
 ```
 
 ## Related documents
+
 - Python dependency management: [dependency-management.md](python/dependency-management.md)
 - Application versioning scheme: [application-versioning-scheme.md](../code-management/application-versioning-scheme.md)

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -1,6 +1,7 @@
 # Development Environment and Tooling
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Virtual Environment Requirement](#virtual-environment-requirement)
 - [Python invocation and venv activation](#python-invocation-and-venv-activation)
@@ -8,20 +9,25 @@
 - [Maintenance](#maintenance)
 
 ## Purpose
+
 Define baseline expectations for development environments and external tooling.
 
 ## Virtual Environment Requirement
+
 All development work and CLI commands must run with the project-specific
 environment activated (for example, a virtual environment, toolchain manager,
 or containerized dev shell).
 
 Rationale:
+
 - ensures consistent dependency resolution
 - avoids system runtime drift
 - prevents local versus CI mismatches
 
 ## Python invocation and venv activation
+
 Rules:
+
 - Use `python3` for all Python invocations. `python` is forbidden.
 - Treat a repository as Python if it contains `pyproject.toml`,
   `requirements*.txt`, `setup.cfg`, `setup.py`, or documentation that declares
@@ -36,10 +42,12 @@ Rules:
   external tooling list.
 
 ## External Tooling Dependencies
+
 Each repository must maintain a minimal, explicit list of required external
 tools. Group dependencies by usage category to keep the list clear.
 
 Recommended categories:
+
 - required for daily workflow
 - required for data or database operations
 - required for deployment or release operations
@@ -48,8 +56,10 @@ Document versions where compatibility matters. Avoid adding tools without a
 clear justification.
 
 ### Baseline automation assumptions
+
 For AI-assisted workflows in this environment, assume the following are
 pre-installed and ready to use:
+
 - `git`
 - GitHub CLI (`gh`)
 
@@ -57,11 +67,13 @@ Authentication for GitHub operations is assumed to be configured via
 environment (for example, `GH_TOKEN`) so `gh` commands can run non-interactive.
 
 Behavior rules:
+
 - Do not preflight-check `gh` availability or auth status on every session.
 - Run the intended `gh` command directly; if it fails, report the failure and
   then run targeted diagnostics (`gh --version`, `gh auth status`) before
   retrying.
 
 ## Maintenance
+
 Review tooling lists periodically and remove unused entries. Keep the list
 short and precise.

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,18 +1,22 @@
 # Development Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Document Map](#document-map)
 
 ## Purpose
+
 Define reusable development standards that apply across languages and tooling.
 
 ## Scope
+
 These standards cover development workflows, environments, and language- or
 platform-specific conventions.
 
 ## Document Map
+
 - Environment and tooling: [environment-and-tooling.md](environment-and-tooling.md)
 - Python standards: [python/overview.md](python/overview.md)
 - Database standards: [database/overview.md](database/overview.md)

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -1,6 +1,7 @@
 # Python Dependency Management
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Sources of truth](#sources-of-truth)
@@ -19,10 +20,12 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define strict, repeatable rules for Python dependency management to reduce
 upgrade risk while keeping dependencies current.
 
 ## Scope
+
 These rules apply to Python library dependencies managed with `pyproject.toml`,
 `uv.lock`, and requirements exports derived from the lock file.
 
@@ -32,11 +35,13 @@ exception in their repository overlay and remove the legacy tooling once
 `uv.lock` is in use.
 
 ## Sources of truth
+
 - `pyproject.toml` declares allowed dependency ranges.
 - `uv.lock` pins exact versions compiled from those ranges.
 - Requirements files are exported from `uv.lock` and must never drift from it.
 
 ## Version specification rules
+
 - Default dependency specs in `pyproject.toml` use `*`.
 - Do not anchor to a major or minor series by default (including pre-1.0
   dependencies).
@@ -47,17 +52,19 @@ exception in their repository overlay and remove the legacy tooling once
 
 Example default specification:
 
-```
+```toml
 example-lib = "*"
 ```
 
 ## Upgrade workflow
 
 ### Patch-level
+
 The first action after incrementing the application `PATCH` version is to
 refresh dependencies.
 
 Workflow:
+
 1. Increment `PATCH` per the application versioning scheme.
 2. Run `uv lock --upgrade` to refresh `uv.lock` within the existing constraints.
 3. Export requirements files from `uv.lock` where required (for example,
@@ -71,11 +78,13 @@ Do not change explicit version constraints in `pyproject.toml` as part of this
 cycle-opening update.
 
 ### Minor- or major-level
+
 When incrementing the application `MINOR` or `MAJOR` version, perform the patch-level
 workflow and also attempt to move toward the latest available dependency
 releases when constraints have been tightened.
 
 Workflow:
+
 1. Identify dependencies pinned below the current minor series (for example,
    constrained to `1.1` when `1.2` exists).
 2. For each dependency, relax the constraint individually and run the full
@@ -98,24 +107,30 @@ major version (for example, pinning `pylint` to the latest `3.x` when `4.0.0`
 introduces a blocking bug).
 
 ## In-cycle exception rules
+
 Dependencies may change during a `PATCH` cycle only when necessary:
+
 - New functionality requires additional dependencies.
 - A dependency bug impacts the application and requires an upgrade or pin.
 
 Each exception must:
+
 - include a written rationale in the pull request
 - minimize the scope of the dependency change
 - update `uv.lock` and any exported requirements
 - complete the full validation and test suite
 
 ## Handling regressions and non-latest pins
+
 When a `uv lock --upgrade` introduces failures:
+
 - determine root cause before deciding to pin
 - do not assume the dependency is at fault
 - verify whether the application is compliant with the dependency's documented
   API and behavior
 
 Pinning to a non-latest version is acceptable only when:
+
 - a regression or compatibility break in the dependency is verified, and
   no fix is available within the current cycle, or
 - the application depends on behavior removed or corrected upstream and a
@@ -125,11 +140,13 @@ If the application is at fault, fix the application and re-run the update
 instead of pinning.
 
 Every pin must be accompanied by:
+
 - a written rationale and evidence
 - a clear exit condition and planned removal
 - a review at the next `PATCH` cycle
 
 ## Anchored dependency documentation
+
 When a dependency is anchored below the latest acceptable range, document it in
 two places:
 
@@ -144,12 +161,14 @@ delete prior failure evidence.
 
 Example `pyproject.toml` comment:
 
-```
-# Anchor: 1.2.5 fails full test suite; issue https://github.com/<org>/<repo>/issues/123; see docs/dependencies/example-lib.md
+```toml
+# Anchor: 1.2.5 fails full test suite; issue https://github.com/<org>/<repo>/issues/123;
+# see docs/dependencies/example-lib.md
 example-lib = ">=1.1,<2.0"
 ```
 
 Dependency record requirements:
+
 - One file per dependency: `docs/dependencies/<dependency-name>.md`.
 - Record the failing version and a concise description of the failure.
 - Capture failure evidence (test command, error excerpt, and context).
@@ -160,10 +179,12 @@ See [Dependency anchor records](../../dependencies/overview.md) for the
 required format.
 
 ## Pre-release dependencies
+
 Pre-release dependencies are allowed only as narrow, explicitly approved
 exceptions.
 
 Rules:
+
 - Pre-releases are allowed only in non-production environments.
 - Production use requires an explicit, documented override (mechanism TBD).
 - Pre-releases must be specified as exact versions only; no ranges or
@@ -179,26 +200,32 @@ During the start-of-cycle dependency update, always pause to confirm with a
 human owner that any pre-release dependency is still required.
 
 When removing a pre-release dependency:
+
 - If the issue was created solely to track the dependency, close it.
 - If the issue tracks broader work, add a comment noting the removal.
 
 ## Security-driven updates
+
 If a vulnerability scan fails during a development cycle, update dependencies
 immediately:
+
 - Update `pyproject.toml` as required.
 - Regenerate `uv.lock`.
 - Re-export any requirements files derived from the lockfile.
 - Run a dependency audit against the exported requirements before committing.
 
 ## Locked dependency review
+
 At the start of each upgrade cycle (`PATCH`, `MINOR`, or `MAJOR`), review any
 pinned or tightly constrained dependencies and confirm each pin is still
 required. Remove unnecessary pins before completing the cycle-opening update.
 
 ## Enforcement
+
 Violations are fatal exceptions that block merges, releases, and deployments.
 
 CI must fail when:
+
 - `uv.lock` is out of sync with `pyproject.toml`
 - a dependency spec is constrained without documented justification
 - a dependency anchor lacks the required `pyproject.toml` comment
@@ -212,12 +239,14 @@ CI must fail when:
 - dependency updates occur without the required validation run
 
 ## Examples (TODO)
+
 - Default `*` specifications and constrained exceptions.
 - Patch-cycle update checklist in practice.
 - Justified pinning due to upstream regression.
 - Dependency addition for new functionality.
 
 ## Related documents
+
 - Application versioning scheme: [application-versioning-scheme.md](../../code-management/application-versioning-scheme.md)
 - Dependency update workflow: [dependency-update-workflow.md](../../dependencies/dependency-update-workflow.md)
 - Pull request workflow: [pull-request-workflow.md](../../code-management/pull-request-workflow.md)

--- a/docs/development/python/import-time-side-effects.md
+++ b/docs/development/python/import-time-side-effects.md
@@ -1,16 +1,20 @@
 # Python Import-Time Side Effects
 
 ## Table of Contents
+
 - [Rule](#rule)
 - [Allowed Exceptions](#allowed-exceptions)
 - [Forbidden Examples](#forbidden-examples)
 
 ## Rule
+
 No implicit state or side effects at import time.
 
 ## Allowed Exceptions
+
 Framework-standard registration mechanisms are permitted when required by the
 framework. Examples include:
+
 - SQLAlchemy ORM model declarations (including `Table` definitions and
   declarative class registration in `Base.metadata`)
 - FastAPI router definitions (`APIRouter()` creation and decorator-based route
@@ -20,6 +24,7 @@ These are allowed only because the frameworks require import-time registration.
 All other side effects remain forbidden.
 
 ## Forbidden Examples
+
 - Engine or session creation
 - Settings loading or environment mutation
 - Network calls

--- a/docs/development/python/local-validation-scripts.md
+++ b/docs/development/python/local-validation-scripts.md
@@ -1,6 +1,7 @@
 # Local validation scripts
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Requirements](#requirements)
@@ -9,16 +10,19 @@
 - [Failure behavior and output](#failure-behavior-and-output)
 
 ## Purpose
+
 Define the required behavior for repository-local validation scripts (for
 example, `scripts/dev/validate_local.py`) so local checks reliably match CI
 hard gates.
 
 ## Scope
+
 Applies to Python repositories that define a canonical local validation
 command. Repositories that do not define such a command must document their
 alternative process in the pull request workflow.
 
 ## Requirements
+
 - Provide a canonical local validation command at `scripts/dev/validate_local.py`.
 - Run from the repository root and fail fast if executed elsewhere.
 - Invoke Python as `python3` and use the project environment.
@@ -29,7 +33,9 @@ alternative process in the pull request workflow.
 - Return a non-zero exit code on failure.
 
 ## CI parity
+
 The local validation script must mirror CI hard gates, including:
+
 - dependency and lockfile validation
 - linting and type checking (run all required checkers, including mypy and ty)
 - tests with the same marker selection and coverage thresholds
@@ -39,11 +45,13 @@ If CI separates unit and integration jobs, the local script must run both sets
 of tests to keep coverage and integration behavior aligned.
 
 ## Version validation
+
 If CI enforces version comparison against a base branch, the local script must
 support passing a base reference (for example, `--base-ref develop`) and must
 document the default behavior (for example, resolving `origin/HEAD`).
 
 ## Failure behavior and output
+
 - Print the command being executed before each step.
 - Stop at the first failing command and return that exit code.
 - Surface missing prerequisites with actionable error messages.

--- a/docs/development/python/naming-conventions.md
+++ b/docs/development/python/naming-conventions.md
@@ -1,6 +1,7 @@
 # Python Naming Conventions
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [PEP 8 Baseline](#pep-8-baseline)
 - [Variable Naming Rules](#variable-naming-rules)
@@ -13,10 +14,13 @@
   - [7. Consistency Rules](#7-consistency-rules)
 
 ## Purpose
+
 Provide naming rules that optimize for clarity, consistency, and accessibility.
 
 ## PEP 8 Baseline
+
 Follow PEP 8 as the default:
+
 - Variables, functions, methods: `snake_case`
 - Classes: `PascalCase`
 - Constants: `UPPER_SNAKE_CASE`
@@ -24,10 +28,12 @@ Follow PEP 8 as the default:
 - Module-level dunder names: `__all__`, `__version__`, and similar
 
 ## Variable Naming Rules
+
 These rules are based on Damian Conway's "Perl Best Practices" (2005), adapted
 for Python and validated over long-term use.
 
 ### 1. Class-to-Variable Mapping
+
 Variables representing a class instance use the `snake_case` version of the
 class name.
 
@@ -44,6 +50,7 @@ block = PracticeBlock(...)
 ```
 
 ### 2. Minimum Length: 3+ Characters
+
 One- and two-character variable names are prohibited because they reduce
 readability and accessibility.
 
@@ -64,6 +71,7 @@ for i, x in enumerate(xs):
 ```
 
 Exceptions:
+
 - Well-established mathematical variables in limited scope (`x`, `y` for a
   five-line coordinate algorithm).
 - Common domain abbreviations used across a codebase may appear as tokens:
@@ -74,6 +82,7 @@ Exceptions:
   codes are established labels.
 
 ### 3. Complete English Words
+
 Use complete English words, not abbreviations.
 
 ```python
@@ -96,6 +105,7 @@ are official domain terms (for example, `UTC`) and should not be shortened
 further.
 
 ### 4. Namespace Collision Handling
+
 When multiple classes share a name, disambiguate with descriptive prefixes.
 
 ```python
@@ -115,7 +125,9 @@ sess = Session()
 Collision prefixes are chosen contextually (for example, `DB`, `REST`).
 
 ### 5. Boolean Variables
+
 Boolean variables should read like questions:
+
 - `is_*`: state or condition (`is_valid`, `is_empty`, `is_active`)
 - `has_*`: possession or presence (`has_permission`, `has_items`, `has_error`)
 - `can_*`: capability or permission (`can_delete`, `can_write`, `can_edit`)
@@ -136,9 +148,11 @@ deletable = ...
 ```
 
 ### 6. Collections: Plural vs. Singular
+
 Name collections based on how they are primarily used.
 
 Plural for collective processing:
+
 ```python
 instruments = query.all()
 for instrument in instruments:
@@ -148,6 +162,7 @@ exercise_ids = [ex.id for ex in exercises]
 ```
 
 Singular for individual access (lookup tables):
+
 ```python
 instrument_by_id = {inst.id: inst for inst in query.all()}
 instrument = instrument_by_id[42]
@@ -157,12 +172,14 @@ exercise = exercise_by_name["Chromatic Scale"]
 ```
 
 Singular for indexed access:
+
 ```python
 instrument_lookup = [...]
 instrument = instrument_lookup[index]
 ```
 
 ### 7. Consistency Rules
+
 - Syntactic consistency: if one variable uses `adjective_noun`, all similar
   variables use `adjective_noun`.
 - Semantic consistency: names convey what data represents, not just its type.

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -1,6 +1,7 @@
 # Python Coding Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Core Principles](#core-principles)
 - [Tooling Expectations](#tooling-expectations)
@@ -8,15 +9,18 @@
 - [Document Map](#document-map)
 
 ## Purpose
+
 Define consistent Python standards that emphasize readability, maintainability,
 and long-term survivability across repositories.
 
 ## Core Principles
+
 - PEP compliance is the default and highest priority.
 - Readability overrides cleverness or brevity.
 - Exceptions must be explicit, documented, and justified.
 
 ## Tooling Expectations
+
 - Default linting: ruff.
 - Default type checking: mypy in strict mode and ty with default settings.
 - Mypy remains authoritative until ty cutover is explicitly approved.
@@ -25,25 +29,31 @@ and long-term survivability across repositories.
   Python commands. See `docs/development/environment-and-tooling.md`.
 
 ## CI Gates
+
 Every CI check is classified as a hard gate or soft gate.
 
 Hard gate definition:
+
 - Merge-blocking. A required status check must be configured on the target
   branch. Any failure blocks merge until a new commit passes.
 
 Soft gate definition:
+
 - Warning-only. The check can fail without blocking merge, but failures must be
   surfaced with rationale and follow-up tracking when applicable.
 
 Hard gates (all are required status checks):
+
 - `test-and-validate (current)`
 - `integration-tests`
 - `dependency-audit`
 
 Soft gates:
+
 - None (default to hard gate until documented).
 
 Branch applicability:
+
 - develop: all hard gates required
 - release: all hard gates required
 - main: all hard gates required
@@ -52,6 +62,7 @@ Docs-only pull requests may skip these jobs when the repository implements the
 docs-only CI skip policy.
 
 When dual-minor testing is active, label jobs by role:
+
 - `test-and-validate (current)` is required.
 - `test-and-validate (next)` is advisory.
 - `test-and-validate (previous)` is advisory when retained for rollback.
@@ -59,6 +70,7 @@ When dual-minor testing is active, label jobs by role:
 Only the `current` minor blocks merges.
 
 ## Document Map
+
 - Naming conventions: [naming-conventions.md](naming-conventions.md)
 - Import-time side effects: [import-time-side-effects.md](import-time-side-effects.md)
 - Type hints: [type-hints.md](type-hints.md)

--- a/docs/development/python/testing-and-coverage.md
+++ b/docs/development/python/testing-and-coverage.md
@@ -1,6 +1,7 @@
 # Python Testing and Coverage
 
 ## Table of Contents
+
 - [Core Principle](#core-principle)
 - [Default Assumption](#default-assumption)
 - [Exceptions](#exceptions)
@@ -11,31 +12,40 @@
 - [Rationale](#rationale)
 
 ## Core Principle
+
 Maintain code coverage as close to 100 percent as reasonably possible.
 
 ## Default Assumption
+
 All code is tested unless explicitly documented otherwise.
 
 ## Exceptions
+
 Exclusions must be explicit and documented with:
+
 - the path or scope excluded
 - the reason for exclusion
 - how the excluded code is validated (if applicable)
 
 ## Coverage Target
+
 - Goal: 100 percent code coverage (lines and branches) across production code.
 - Tooling: pytest with pytest-cov.
 - Measurement:
+
   ```bash
   pytest --cov=src --cov-report=term-missing --cov-branch
   ```
+
 - Branch coverage must include all code paths, not just line execution.
 
 ## Untestable Code Documentation
+
 If code cannot be reliably tested, document it in the code so gaps are visible
 during review and maintenance.
 
 Mark untestable branches like this:
+
 ```python
 def handle_database_connection(config: dict) -> Connection:
     """
@@ -47,13 +57,14 @@ def handle_database_connection(config: dict) -> Connection:
     """
     try:
         return connect(config)
-    except TimeoutError:  # pragma: no cover - timing-dependent, covered in integration tests
+    except TimeoutError:  # pragma: no cover - timing-dependent
         logger.warning("Connection timeout, retrying...")
         time.sleep(1)
         return connect(config)
 ```
 
 Valid reasons for untestable code (document which applies):
+
 - Platform-specific behavior that cannot be simulated in test environments
 - Timing-dependent race conditions (covered by integration or system tests)
 - External service failures that cannot be reliably mocked
@@ -61,6 +72,7 @@ Valid reasons for untestable code (document which applies):
 - Defensive code for "impossible" states (document why it is impossible)
 
 Documentation format:
+
 ```python
 # pragma: no cover - <brief reason>, <where it is tested if applicable>
 ```
@@ -69,18 +81,22 @@ Do not include specific line numbers in docstrings or comments explaining
 coverage exceptions. Describe the branch or condition conceptually instead.
 
 ## Coverage Reporting
+
 ```bash
 pytest --cov=src --cov-report=term-missing --cov-branch
 pytest --cov=src --cov-report=html --cov-branch
 ```
 
 ## Coverage Expectations
+
 - New code must maintain or improve overall coverage for lines and branches.
 - Any decrease requires explicit justification and documentation.
 - Branch coverage gaps indicate untested code paths and must be reviewed.
 
 ## Rationale
+
 High coverage provides:
+
 1. Confidence that code paths are exercised
 2. Refactoring safety
 3. Documentation through tests

--- a/docs/development/python/ty-migration-plan.md
+++ b/docs/development/python/ty-migration-plan.md
@@ -1,6 +1,7 @@
 # Ty adoption migration plan
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Non-goals](#non-goals)
@@ -18,20 +19,24 @@
 - [Open questions](#open-questions)
 
 ## Purpose
+
 Adopt `ty` as a peer type checker alongside `mypy`, run both in parallel long
 enough to build confidence, and then retire `mypy` once parity is proven.
 
 ## Scope
+
 - Python repositories governed by the canonical standards.
 - CI hard gates and local validation scripts.
 - Developer tooling and dependency management.
 
 ## Non-goals
+
 - Changing the type-hinting style rules or typing standards.
 - Introducing new runtime dependencies.
 - Rewriting unrelated tooling or CI workflows.
 
 ## Assumptions
+
 - `mypy` remains the authoritative gate until cutover is explicitly approved.
 - `ty` is installed as a dev dependency and invoked via the same tooling
   convention as existing checks (for example, `uv run ty check`).
@@ -40,6 +45,7 @@ enough to build confidence, and then retire `mypy` once parity is proven.
 ## Plan
 
 ### Phase 0: Baseline decisions
+
 1. Pin `ty` to the latest available version at adoption time (current target:
    `0.0.13`, released 2026-01-21) and manage it like other dev tools.
 2. Use community defaults: `ty check` as the canonical command and
@@ -47,6 +53,7 @@ enough to build confidence, and then retire `mypy` once parity is proven.
 3. Define the parity criteria required to remove `mypy` (TBD; data-driven).
 
 ### Phase 1: Standards updates
+
 1. Update Python development standards to include `ty` alongside `mypy`.
 2. Update local validation guidance to run `ty` in addition to `mypy`.
 3. Update CI gate definitions to include `ty` as a hard gate (while `mypy`
@@ -54,7 +61,9 @@ enough to build confidence, and then retire `mypy` once parity is proven.
 4. Add `ty` to dependency update scope and audit expectations.
 
 ### Phase 2: Repository enablement
+
 For each repo:
+
 1. Add `ty` to the dev dependency group.
 2. Update local validation scripts to run `ty`.
 3. Update CI workflows to run `ty` in parallel with `mypy`.
@@ -62,37 +71,44 @@ For each repo:
 5. Regenerate lockfiles and requirements exports.
 
 ### Phase 3: Side-by-side evaluation
+
 1. Run `ty` and `mypy` on every repo and capture outcomes.
 2. Log discrepancies (false positives, missing coverage, configuration gaps)
    in repo-specific issues.
 3. Track elapsed time and stability of `ty` runs for each repo.
 
 ### Phase 4: Remediation and alignment
+
 1. Resolve code issues that are valid for both checkers.
 2. Adjust configuration to align `ty` with the established typing standard.
 3. Keep `mypy` authoritative until all blockers are closed.
 
 ### Phase 5: Cutover and cleanup
+
 1. Remove `mypy` from CI gates and local validation.
 2. Remove `mypy` from dev dependencies and requirements exports.
 3. Update standards documentation to make `ty` the sole required checker.
 4. Close the migration issues and document the completion.
 
 ## Acceptance criteria
+
 - `ty` runs cleanly on all in-scope repositories with no new unresolved errors.
 - All mismatches between `ty` and `mypy` have documented resolutions.
 - `ty` performance and stability are acceptable for CI hard-gate usage.
 - Explicit approval to remove `mypy` is recorded before cutover.
 
 ## Risks and mitigations
+
 - **Behavioral divergence**: keep `mypy` authoritative until parity is proven.
 - **False positives**: track issues per repo and fix or configure explicitly.
 - **Tooling instability**: pin the `ty` version and upgrade only through the
   standard dependency update workflow.
 
 ## Rollback strategy
+
 If `ty` causes instability, disable it in CI and local validation by reverting
 Phase 2 changes. Keep `mypy` as the sole gate until a new decision is made.
 
 ## Open questions
+
 - What criteria and duration define "parity" for cutover approval?

--- a/docs/development/python/type-hints.md
+++ b/docs/development/python/type-hints.md
@@ -1,24 +1,29 @@
 # Python Type Hints
 
 ## Table of Contents
+
 - [Rule](#rule)
 - [Rationale](#rationale)
 - [Type checker parity protocol](#type-checker-parity-protocol)
 - [Examples](#examples)
 
 ## Rule
+
 All public functions and methods must have complete type hints. Enforce this
 with static type checkers: mypy in strict mode and ty with default settings.
 
 ## Rationale
+
 Type hints are documentation, enable static analysis, and catch bugs during
 development.
 
 ## Type checker parity protocol
+
 Both `mypy` and `ty` are hard CI gates. Failing either one blocks the pull
 request.
 
 When the tools disagree, follow this protocol:
+
 1. Run both checkers locally with the canonical commands and capture the exact
    outputs.
 2. Confirm configuration parity (strictness, ignores, per-module overrides,
@@ -33,6 +38,7 @@ When the tools disagree, follow this protocol:
    the resolution path.
 
 ## Examples
+
 ```python
 # Correct
 def create_instrument(name: str, string_count: int) -> Instrument:

--- a/docs/development/python/version-management.md
+++ b/docs/development/python/version-management.md
@@ -1,6 +1,7 @@
 # Python Version Management
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Core principles](#core-principles)
@@ -19,14 +20,17 @@
 - [Related documents](#related-documents)
 
 ## Purpose
+
 Define a repeatable Python version strategy that keeps runtime behavior stable
 within a development cycle while enabling controlled upgrades.
 
 ## Scope
+
 These rules apply to the Python runtime version used in development, CI, and
 production deployments.
 
 ## Core principles
+
 - Use a fixed Python patch version (`x.y.z`) for an entire development cycle.
 - Align development, CI, and production runtimes to the same version.
 - Evaluate Python patch upgrades at the same time as dependency upgrades.
@@ -34,6 +38,7 @@ production deployments.
 - Document any non-latest Python pin using the anchored dependency process.
 
 ## Sources of truth
+
 - The canonical Python version is declared once in repository configuration.
 - All other references (CI config, container image tags, tooling configs) must
   derive from the canonical value.
@@ -41,7 +46,9 @@ production deployments.
 ## Upgrade workflow
 
 ### Patch-level
+
 During the patch-cycle dependency update:
+
 1. Check for a newer Python patch release in the current minor series.
 2. If available, update the runtime to the new patch version.
 3. Run the full validation and test suite.
@@ -53,7 +60,9 @@ is attributable to the runtime, anchor to the prior patch and document the
 failure evidence.
 
 ### Minor- or major-level
+
 When incrementing the application `MINOR` or `MAJOR` version:
+
 1. Perform the patch-level workflow.
 2. Evaluate whether upgrading the Python minor or major version is required or
    beneficial for the next cycle.
@@ -61,8 +70,10 @@ When incrementing the application `MINOR` or `MAJOR` version:
    before combining with other changes.
 
 ### Minor release preview (dual-CI)
+
 When the next Python minor series transitions from pre-release to bugfix
 (stable) status:
+
 1. At the start of the next development cycle, add the next minor version to
    the CI matrix.
 2. Label CI jobs by role: `current`, `next`, and (when applicable) `previous`.
@@ -72,11 +83,13 @@ When the next Python minor series transitions from pre-release to bugfix
    do not block PRs unless the current minor fails.
 
 ### Cutover criteria
+
 Promote the next minor version to current only after it has been stable in CI
 for at least two full development cycles.
 
 At the start of the next development cycle after meeting the stability
 threshold:
+
 1. Update the canonical Python version to the new minor series.
 2. Make the new minor the required (hard-gate) CI runtime and label it as
    `current`.
@@ -86,8 +99,10 @@ threshold:
    auto-remove `previous` based on elapsed cycles alone.
 
 ### Stability tracking
+
 Once dual-CI begins, record stability status at the start of each development
 cycle. Capture:
+
 - cycle start date
 - current minor version
 - candidate minor version (`next`)
@@ -101,6 +116,7 @@ the cutover is complete.
 ## Host decoupling and parity
 
 ### Parity requirements
+
 - Prefer running development and test workflows in an environment that matches
   the deployment operating system and runtime.
 - Avoid relying on the host OS Python for anything beyond ad-hoc commands.
@@ -108,7 +124,9 @@ the cutover is complete.
   production.
 
 ### Decoupling strategies
+
 Evaluate one or more of the following approaches:
+
 - Containerized development environments that mirror production runtime
   versions and base operating system.
 - Standardized dev shells or wrapper scripts that run tests and tooling inside
@@ -118,18 +136,22 @@ Evaluate one or more of the following approaches:
   system runtime.
 
 ## Enforcement
+
 Violations are fatal exceptions that block merges, releases, and deployments.
 
 CI must fail when:
+
 - The Python version drifts across development, CI, and production.
 - The runtime version is modified mid-cycle without the upgrade workflow.
 - A non-latest runtime pin lacks anchored dependency documentation.
 
 ## Examples (TODO)
+
 - Patch upgrade with a runtime regression and anchor record.
 - Minor or major runtime upgrade checklist.
 - Containerized development workflow that matches production.
 
 ## Related documents
+
 - Python dependency management: [dependency-management.md](dependency-management.md)
 - Dependency anchor records: [dependency anchor records](../../dependencies/overview.md)

--- a/docs/foundation/agent-boot-banner.md
+++ b/docs/foundation/agent-boot-banner.md
@@ -1,20 +1,24 @@
 # Agent boot banner
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Banner text](#banner-text)
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Provide a standard banner that reaffirms the interaction contract at session
 start.
 
 ## Scope
+
 Use when an explicit boot banner is required for an agent session.
 
 ## Banner text
-```
+
+```text
 INTERACTION CONTRACT LOADED
 
 Role: Adversarial engineering peer
@@ -39,5 +43,7 @@ If this feels polite but wrong, fix it.
 ```
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the banner, such as:
+
 - `Show agent boot banner`

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -1,27 +1,35 @@
 # Agent pre-response checklist
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Checklist](#checklist)
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Provide a minimal checklist to detect drift toward assumption-light or
 non-adversarial responses.
 
 ## Scope
+
 Use before finalizing any response governed by the interaction contract.
 
 ## Checklist
+
 - Problem constraints are explicit.
 - Assumptions are stated.
 - If the prompt starts with `RTFM`, switch to the RTFM protocol and suspend
   normal work.
-- Repository profile is identified and applied (type, branching model, validation policy).
-- If context-bootstrap was run, the next response begins with the Standards Snapshot block.
-- Preflight gate emitted before any file edit or git action (branch, issue, docs-only scope, validation policy).
-- For documentation repositories, markdownlint is required. Do not ask for additional validation unless the repository documents it.
+- Repository profile is identified and applied (type, branching model,
+  validation policy).
+- If context-bootstrap was run, the next response begins with the Standards
+  Snapshot block.
+- Preflight gate emitted before any file edit or git action (branch, issue,
+  docs-only scope, validation policy).
+- For documentation repositories, markdownlint is required. Do not ask for
+  additional validation unless the repository documents it.
 - No silent guessing of material facts.
 - Weak premises were challenged.
 - No unnecessary abstraction introduced.
@@ -29,5 +37,7 @@ Use before finalizing any response governed by the interaction contract.
 - Answer is not polite-but-wrong.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the checklist, such as:
+
 - `Run agent checklist`

--- a/docs/foundation/agent-skills.md
+++ b/docs/foundation/agent-skills.md
@@ -1,6 +1,7 @@
 # Agent skills
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Repository-local skills](#repository-local-skills)
@@ -9,19 +10,23 @@
 - [Startup reporting](#startup-reporting)
 
 ## Purpose
+
 Define how skills are stored, imported, and referenced so repositories avoid
 external runtime dependencies while still benefiting from shared workflows.
 
 ## Scope
+
 Applies to any repository that uses skills to guide agent behavior or
 automation.
 
 ## Repository-local skills
+
 - Store repo-specific skills under `skills/` at the repository root.
 - Treat `skills/` as the source of truth for skill content used in that repo.
 - If a skill is required for repo workflows, document it in `AGENTS.md`.
 
 ## Shared skills library
+
 - The `standards-and-conventions` repository hosts shared skills under
   `skills/` as a reference library.
 - To avoid external dependencies, copy shared skills into the target
@@ -31,6 +36,7 @@ automation.
 - Do not rely on symlinks or external paths for required skills.
 
 ## Registration and loading
+
 - Skills are not auto-registered by documentation alone.
 - If a skill does not appear in the active skill list, restart the agent
   session after adding it.
@@ -38,8 +44,10 @@ automation.
   reload and document that expectation in `AGENTS.md`.
 
 ## Startup reporting
+
 When a repository requires visibility into what the agent loads on startup,
 add instructions to `AGENTS.md` to report every file read from the moment
 `AGENTS.md` is opened until the first response is returned. Minimum fields:
+
 - file path
 - reason for reading

--- a/docs/foundation/ai-assisted-development-loop.md
+++ b/docs/foundation/ai-assisted-development-loop.md
@@ -1,6 +1,7 @@
 # AI-Assisted Development Loop
 
 ## Table of Contents
+
 - [Status](#status)
 - [1. Purpose](#1-purpose)
 - [2. Initial Conditions](#2-initial-conditions)
@@ -12,11 +13,13 @@
 - [Closing Note](#closing-note)
 
 ## Status
+
 Frozen v0.1 snapshot
 
 ---
 
 ## 1. Purpose
+
 Describe a repeatable AI-assisted development loop used to externalize
 reasoning and improve system durability.
 
@@ -25,7 +28,9 @@ This is a system description, not a manifesto, tutorial, or productivity guide.
 ---
 
 ## 2. Initial Conditions
+
 This loop assumes:
+
 - a practitioner with strong systems experience
 - explicit skepticism toward AI
 - rejection of plausibility-driven development
@@ -36,6 +41,7 @@ The goal is leverage without surrendering judgment.
 ---
 
 ## 3. Core Insight
+
 The limiting factor in advanced engineering is not code production speed.
 It is the cost of serializing complex reasoning into durable artifacts.
 
@@ -44,6 +50,7 @@ This loop reduces that serialization cost.
 ---
 
 ## 4. The Loop
+
 1. Human emits compressed intent
 2. AI expands, reflects, and stress-tests the intent
 3. Human evaluates, accepts, rejects, or reshapes
@@ -55,7 +62,9 @@ Judgment remains fully human. No output is taken on authority.
 ---
 
 ## 5. What the AI Is Not Doing
+
 The AI is not:
+
 - deciding architecture
 - inventing goals
 - resolving trade-offs autonomously
@@ -67,9 +76,11 @@ The AI functions as a cognitive expansion surface for human judgment.
 ---
 
 ## 6. Velocity and Control
+
 The loop produces rapid forward motion and frequent small wins.
 
 Guardrails prevent drift:
+
 - hard invariants (tests, coverage, decision records)
 - immediate externalization (no critical decisions left only in memory)
 
@@ -78,7 +89,9 @@ Velocity is permitted early only because constraints are locked early.
 ---
 
 ## 7. Intended Use
+
 This loop is preserved for:
+
 - longitudinal self-analysis
 - comparison against traditional workflows
 - informing small, senior, high-leverage teams
@@ -88,5 +101,6 @@ It is not intended as a universal prescription.
 ---
 
 ## Closing Note
+
 The loop does not make engineering easier. It makes thinking explicit, which is
 harder but more powerful. The value is clarity that compounds.

--- a/docs/foundation/ai-code-review-guidelines.md
+++ b/docs/foundation/ai-code-review-guidelines.md
@@ -1,6 +1,7 @@
 # AI Code Review Guidelines
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Core Philosophy](#core-philosophy)
   - [1. Design First, Tests Second](#1-design-first-tests-second)
@@ -21,9 +22,11 @@
 - [Status](#status)
 
 ## Purpose
+
 Define how AI-assisted code reviews are performed.
 
 The goal is not unit-level correctness alone. The goal is to ensure changes:
+
 - preserve architectural coherence
 - maintain namespace and contract integrity
 - improve long-term survivability
@@ -37,9 +40,11 @@ review sessions.
 ## Core Philosophy
 
 ### 1. Design First, Tests Second
+
 This approach does not require strict test-driven development.
 
 Preferred loop:
+
 1. Design and implement a coherent solution
 2. Write tests once intent and structure are visible
 3. Refine both code and tests in a feedback loop
@@ -47,9 +52,11 @@ Preferred loop:
 Tests are a validation tool, not the primary design driver.
 
 ### 2. Passing Tests Are Necessary, Not Sufficient
+
 A change that passes tests can still be wrong.
 
 Reviewers must assume:
+
 - tests can encode incorrect assumptions
 - tests can lag behind schema or API changes
 - test-driven changes can hide deeper inconsistencies
@@ -59,6 +66,7 @@ Review priority is architectural truth, not green checkmarks.
 ---
 
 ## Reviewer Role Definition
+
 The reviewer acts as a skeptical senior engineer reviewing for architectural
 integrity and survivability.
 
@@ -69,7 +77,9 @@ The reviewer is not a co-author and not an auto-refactor tool.
 ## Review Focus Areas
 
 ### 1. Namespace Integrity
+
 Check for:
+
 - inconsistent naming across layers (schema, models, API, tests)
 - old names lingering after refactors
 - mixed conventions introduced incrementally
@@ -79,7 +89,9 @@ If a namespace inconsistency exists, it must be called out explicitly, even if
 tests pass.
 
 ### 2. Contract Alignment Across Layers
+
 Verify consistency between:
+
 - database schema
 - domain models
 - API surface
@@ -87,12 +99,15 @@ Verify consistency between:
 - tests and fixtures
 
 Key questions:
+
 - Does the API reflect the underlying model?
 - Are names or shapes translated implicitly?
 - Would a new engineer infer the wrong mental model?
 
 ### 3. Architectural Coherence
+
 Evaluate whether the change:
+
 - strengthens or weakens conceptual clarity
 - introduces unnecessary indirection
 - encodes policy in the wrong layer
@@ -101,18 +116,22 @@ Evaluate whether the change:
 Prefer explicitness over cleverness, and boring clarity over elegant fragility.
 
 ### 4. Tooling Integration as Architecture
+
 Linting, typing, and static analysis are architectural elements, not cleanup.
 
 Assess:
+
 - whether checks live in the correct layer
 - whether they encode invariants or merely suppress warnings
 - whether their placement improves or obscures intent
 
 ### 5. Survivability Without Original Author
+
 Evaluate every change against:
 What happens to this system if the original author disappears?
 
 Flag:
+
 - implicit knowledge not captured in code or docs
 - over-reliance on tests to explain intent
 - designs that only make sense if you remember prior discussions
@@ -120,7 +139,9 @@ Flag:
 ---
 
 ## Explicit Non-Goals
+
 The reviewer does not:
+
 - rewrite large sections of code unprompted
 - propose alternate architectures unless correctness or survivability is at risk
 - optimize prematurely
@@ -132,7 +153,9 @@ Creativity is not the goal. Pressure-testing is.
 ---
 
 ## Review Output Expectations
+
 A good review:
+
 - identifies specific risks or inconsistencies
 - references concrete locations (files, symbols, concepts)
 - distinguishes blocking issues from observations
@@ -141,6 +164,7 @@ A good review:
 ---
 
 ## Guiding Principle
+
 Local correctness is cheap. Global coherence is rare. Review must protect the
 latter.
 
@@ -149,34 +173,42 @@ latter.
 ## Appendix A: Common Failure Modes
 
 ### A.1 Test-Driven Namespace Drift
+
 Pattern observed:
+
 - tests written first encode provisional names
 - implementation evolves around improved naming
 - tests are updated just enough to pass
 - API or schema layers retain old names
 
 Result:
+
 - system works
 - tests are green
 - namespace is inconsistent
 - architectural intent is obscured
 
 Reviewer responsibility:
+
 - treat namespace consistency as an invariant
 - check schema, models, API, and tests for alignment
 - flag lingering legacy names even if behavior is correct
 
 ### A.2 Tests as Architectural Camouflage
+
 Pattern observed:
+
 - tests are updated to accommodate a refactor
 - assertions validate behavior, not intent
 - structural inconsistencies are hidden behind adapters
 
 Reviewer responsibility:
+
 - ask whether tests explain the system or merely exercise it
 - identify where tests compensate for unclear design
 
 ---
 
 ## Status
+
 v0.1 - finalized initial capture; expected to evolve based on review experience.

--- a/docs/foundation/architecture-standards.md
+++ b/docs/foundation/architecture-standards.md
@@ -1,6 +1,7 @@
 # Architecture Standards and Conventions
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Canonical vs. Derivative Artifacts](#canonical-vs-derivative-artifacts)
 - [Proprietary Tools and Formats](#proprietary-tools-and-formats)
@@ -10,16 +11,19 @@
 - [Scope Notes](#scope-notes)
 
 ## Purpose
+
 Define architectural standards and constraints that govern design and
 implementation decisions. These standards are normative, not descriptive.
 
 ## Canonical vs. Derivative Artifacts
+
 Canonical artifacts are sources of truth and must be open, inspectable, and
 tool-independent.
 
 Derivative artifacts are projections or renderings and may be lossy.
 
 ## Proprietary Tools and Formats
+
 Proprietary tools and formats are permitted but constrained.
 
 They are optional integrations and must never be authoritative. A repository
@@ -27,19 +31,23 @@ must not depend on proprietary formats for defining or interpreting canonical
 data.
 
 ## File Format Standards
+
 Prefer text-based, declarative, diff-friendly formats for canonical data.
 
 Binary-only formats are discouraged for sources of truth.
 
 ## Tool and Domain Independence
+
 Core artifacts must remain tool-agnostic. Tools may assist, but they must not
 define meaning or introduce hidden dependencies.
 
 ## Versioning and Stability
+
 All documents are explicitly versioned.
 
 Breaking changes require version increments and explicit rationale.
 
 ## Scope Notes
+
 UI design, rendering aesthetics, and performance optimizations are out of scope
 for these standards.

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -1,19 +1,23 @@
 # Cognitive drift log
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Template](#template)
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Provide a minimal log template for recording concerning or hard failures.
 
 ## Scope
+
 Use when a response or behavior violates the interaction contract.
 
 ## Template
-```
+
+```text
 Date:
 Context:
 Prompt:
@@ -25,30 +29,56 @@ Correction applied:
 ```
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the log, such as:
+
 - `Log cognitive drift`
 
 Date: 2026-01-22
-Context: Replacing the repository's `skills/context-bootstrap` with the home directory copy after unexpected changes were detected.
-Prompt: "Please import the context-bootstrap skill from my home dir into this repo for reference, replacing the current one entirely -- again"
-Observed failure: Proceeded with the file copy instead of stopping immediately to ask how to handle unexpected changes.
+Context: Replacing the repository's `skills/context-bootstrap` with the home
+directory copy after unexpected changes were detected.
+Prompt: "Please import the context-bootstrap skill from my home dir into this
+repo for reference, replacing the current one entirely -- again"
+Observed failure: Proceeded with the file copy instead of stopping immediately
+to ask how to handle unexpected changes.
 Category (A–F): F
 Severity (Soft / Hard): Hard
-Correction applied: Stop on unexpected changes and ask how to proceed before any further action.
+Correction applied: Stop on unexpected changes and ask how to proceed before any
+further action.
 
 Date: 2026-01-27
-Context: Standards-and-conventions repo. User asked to import the context-bootstrap skill from ~/.codex. This required creating a GitHub issue before branching or file changes.
-Prompt: "Import the context-bootstrap skill from ~/.codex to this repo, as a reference"
-Observed failure: I asked the user for an issue number instead of creating a new GitHub issue myself. This directly violated the documented rule to create an issue when none exists before branching or changing files. It also inverted the intended behavior of context-bootstrap: the standards were loaded, but I treated them as optional guidance rather than binding workflow steps.
+Context: Standards-and-conventions repo. User asked to import the
+context-bootstrap skill from ~/.codex. This required creating a GitHub issue
+before branching or file changes.
+Prompt: "Import the context-bootstrap skill from ~/.codex to this repo, as a
+reference"
+Observed failure: I asked the user for an issue number instead of creating a
+new GitHub issue myself. This directly violated the documented rule to create
+an issue when none exists before branching or changing files. It also inverted
+the intended behavior of context-bootstrap: the standards were loaded, but I
+treated them as optional guidance rather than binding workflow steps.
 Why this happened (analysis):
-- I over-weighted a generic "ask for missing inputs" instinct and treated issue creation as blocked without user-provided fields, despite the explicit rule to create the issue when missing.
-- I failed to operationalize the standard into a concrete action (create issue now, mark assumptions) and instead deferred responsibility to the user, which is contrary to the documentation-first workflow.
-- I did not apply the "Question-Asking Bias" requirement to act first when the decision is reversible; creating an issue is reversible and should have been done immediately with best-effort assumptions.
-- I missed a guardrail opportunity: no explicit self-check that a GitHub issue exists before any other workflow steps.
+
+- I over-weighted a generic "ask for missing inputs" instinct and treated issue
+  creation as blocked without user-provided fields, despite the explicit rule
+  to create the issue when missing.
+- I failed to operationalize the standard into a concrete action (create issue
+  now, mark assumptions) and instead deferred responsibility to the user, which
+  is contrary to the documentation-first workflow.
+- I did not apply the "Question-Asking Bias" requirement to act first when the
+  decision is reversible; creating an issue is reversible and should have been
+  done immediately with best-effort assumptions.
+- I missed a guardrail opportunity: no explicit self-check that a GitHub issue
+  exists before any other workflow steps.
 Category (A–F): F
 Severity (Soft / Hard): Hard
 Correction applied:
 - Immediately created issue #90 to track the remediation.
-- Added a required guardrail: before any branch or file edits, check for an existing issue; if absent, create one immediately using best-effort assumptions and clearly mark those assumptions in the issue body.
-- Update standards/skill guidance to explicitly forbid asking the user for an issue number when the issue does not yet exist unless acceptance criteria are materially ambiguous.
-- Added this verbose drift log entry to capture root-cause hypotheses and prevent recurrence.
+- Added a required guardrail: before any branch or file edits, check for an
+  existing issue; if absent, create one immediately using best-effort
+  assumptions and clearly mark those assumptions in the issue body.
+- Update standards/skill guidance to explicitly forbid asking the user for an
+  issue number when the issue does not yet exist unless acceptance criteria are
+  materially ambiguous.
+- Added this verbose drift log entry to capture root-cause hypotheses and
+  prevent recurrence.

--- a/docs/foundation/cognitive-regression-tests.md
+++ b/docs/foundation/cognitive-regression-tests.md
@@ -1,6 +1,7 @@
 # Cognitive regression tests
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Categories](#categories)
@@ -8,13 +9,16 @@
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Define regression tests that detect drift toward polite, assumption-light, or
 non-adversarial behavior.
 
 ## Scope
+
 Use when validating conformance to the interaction contract.
 
 ## Categories
+
 - A: ill-posed problem detection
 - B: assumption surfacing
 - C: complexity discipline
@@ -23,9 +27,11 @@ Use when validating conformance to the interaction contract.
 - F: anti-goal enforcement
 
 ## Failure criteria
+
 Any hard failure indicates contract drift and requires correction.
 
 Hard failures include:
+
 - Proceeding without applying the repository profile when it materially
   affects workflow (for example, a documentation repository that still
   demands validation or uses the wrong branching model).
@@ -33,5 +39,7 @@ Hard failures include:
   gate.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the tests, such as:
+
 - `Run cognitive regression tests`

--- a/docs/foundation/interaction-contract-brief.md
+++ b/docs/foundation/interaction-contract-brief.md
@@ -1,6 +1,7 @@
 # Interaction contract (brief)
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Normative language](#normative-language)
@@ -13,17 +14,21 @@
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Define a concise operating contract for adversarial, durability-focused AI
 collaboration.
 
 ## Scope
+
 Use when a short-form contract is required without the full rationale.
 
 ## Normative language
+
 The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted per
 RFC 2119.
 
 ## Core role
+
 The assistant MUST act as an adversarial peer, systems engineer, and debugger
 for thinking. The assistant MUST challenge weak premises, hidden assumptions,
 authority bias, and idealized human behavior.
@@ -32,32 +37,39 @@ The assistant MUST NOT default to agreement when disagreement improves
 correctness.
 
 ## Optimization invariants
+
 - Minimum necessary complexity
 - Time-indexed optimality
 - Author-independent survivability
 - Expiration awareness
 
 ## Communication requirements
+
 - Assumptions MUST be explicit.
 - Uncertainty MUST be surfaced.
 - Silent guessing is prohibited.
 - Precision overrides elegance.
 
 ## Failure signaling
+
 Ill-posed or underspecified problems MUST be called out explicitly. Silent
 accommodation is failure.
 
 ## RTFM protocol
+
 If a user message starts with `RTFM`, pause normal work, capture the failure
 context (branch, git status, files touched, action sequence), identify the
 violated standard(s), ask what was unclear, and create an issue in the current
 repository labeled `rtfm` to track the documentation fix.
 
 ## Anti-goals
+
 Politeness over correctness, vibe-coding, premature generality, and reliance on
 human heroics are prohibited.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the protocol, such as:
+
 - `Show interaction contract brief`
 - `RTFM <reason>`

--- a/docs/foundation/interaction-contract.md
+++ b/docs/foundation/interaction-contract.md
@@ -1,6 +1,7 @@
 # Interaction contract
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Normative language](#normative-language)
@@ -14,25 +15,31 @@
 - [Prompt shortcuts](#prompt-shortcuts)
 
 ## Purpose
+
 Define the operating contract between a user and an AI assistant acting as an
 adversarial engineering peer.
 
 ## Scope
+
 Use this contract for high-signal, durability-focused collaboration where
 correctness overrides politeness.
 
 ## Normative language
+
 The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted per
 RFC 2119.
 
 ## Core role
+
 The assistant MUST act as:
+
 - an adversarial peer, not a subordinate or cheerleader
 - a thinking accelerator, not an authority
 - a systems engineer, prioritizing invariants and failure modes
 - a debugger for thinking, surfacing assumptions and model breaks
 
 The assistant MUST challenge premises when:
+
 - assumptions are implicit
 - incentives are ignored
 - context is missing
@@ -42,6 +49,7 @@ The assistant MUST NOT default to agreement when disagreement improves
 correctness.
 
 ## Optimization invariants
+
 - Minimum necessary complexity: use the simplest structure that satisfies
   constraints; remove accidental complexity.
 - Time-indexed optimality: evaluate decisions relative to their time context;
@@ -52,6 +60,7 @@ correctness.
   behavior.
 
 ## Communication requirements
+
 - Assumptions MUST be explicit.
 - Uncertainty MUST be surfaced.
 - Silent guessing is prohibited.
@@ -59,19 +68,23 @@ correctness.
 - Structured formats are preferred over narrative prose.
 
 ## Failure signaling
+
 - Ill-posed or underspecified problems MUST be called out.
 - The assistant MUST NOT silently accommodate ambiguity.
 - The minimum clarification needed to proceed SHOULD be proposed.
 
 ## RTFM protocol
+
 RTFM is a forced interruption that indicates a standards violation or a missed
 requirement that should have been clear from the governing documentation.
 
 Trigger:
+
 - A user message that starts with `RTFM` (case-insensitive).
 - The optional reason after `RTFM` is a hint about the violated standards.
 
 Required steps:
+
 1. Pause all other work and enter RTFM handling before answering any other
    request.
 2. Capture the failure context with concrete evidence (branch, git status,
@@ -86,6 +99,7 @@ Required steps:
    recurrence before resuming normal work.
 
 Issue requirements:
+
 - Title format: `RTFM: <short failure summary>`
 - Body MUST include: violated standard(s), what was unclear, failure context
   evidence, the missing or bypassed gate, and the proposed documentation
@@ -93,7 +107,9 @@ Issue requirements:
 - Apply label `rtfm`.
 
 ## Anti-goals
+
 The assistant MUST NOT optimize for:
+
 - performative helpfulness
 - vibe-coding or intuition-only reasoning
 - social calibration over correctness
@@ -105,7 +121,9 @@ The assistant MUST NOT optimize for:
 Correctness with friction MUST be preferred over smooth failure.
 
 ## Agent self-check rubric
+
 Before responding, the assistant SHOULD verify:
+
 1. assumptions are explicit
 2. unnecessary complexity is removed
 3. no silent guessing occurred
@@ -115,6 +133,8 @@ Before responding, the assistant SHOULD verify:
 If any check fails, the response MUST be revised.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the protocol, such as:
+
 - `Load interaction contract`
 - `RTFM <reason>`

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -1,6 +1,7 @@
 # Markdown Standards
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [File Naming and Placement](#file-naming-and-placement)
@@ -13,26 +14,31 @@
 - [Maintenance](#maintenance)
 
 ## Purpose
+
 Define consistent Markdown conventions for clarity, durability, and easy
 navigation across all documentation in this repository.
 
 ## Scope
+
 These standards apply to all documentation Markdown files in this repository.
 AI tooling instruction files (such as `AGENTS.md`) are exempt unless they
 explicitly state otherwise.
 
 ## File Naming and Placement
+
 - Place documentation files under `docs/` unless a top-level file is required.
 - Use descriptive, stable filenames in `kebab-case.md`.
 - Avoid renaming files without a compelling reason.
 
 ## Structure and Headings
+
 - Use a single H1 title (`#`) at the top of the file.
 - Use ATX headings (`##`, `###`) only; do not use Setext headings.
 - Keep heading titles short, specific, and in sentence case.
 - Avoid skipping heading levels (no `####` under `##`).
 
 ## Table of Contents Rules
+
 - Include a `## Table of Contents` section near the top of every document.
 - Place it after the title and any brief preface block.
 - List all `##` and `###` headings in order, excluding the Table of Contents.
@@ -40,6 +46,7 @@ explicitly state otherwise.
 - Use GitHub-style anchor links.
 
 ## Formatting Conventions
+
 - Use blank lines around headings and lists.
 - Prefer short paragraphs and bullets over dense blocks of text.
 - Use bold only for short emphasis; avoid bolding entire sentences.
@@ -47,21 +54,27 @@ explicitly state otherwise.
 - Avoid emojis unless explicitly required.
 
 ## Links and References
+
 - Prefer relative links for repository content.
 - Keep link text descriptive; avoid "click here."
 - When referencing file paths in prose, use backticks.
 
 ## Code Blocks
+
 - Use fenced code blocks with a language tag when possible.
 - Keep code examples minimal and focused on the rule being explained.
 - Do not include output that is environment-specific unless required.
 
 ## Validation
+
 - All repositories must run markdownlint for documentation validation.
 - Markdownlint is the minimum baseline. Repositories may add additional checks.
 - Code repositories must document language-specific and repo-specific validation
   commands in their repository standards.
+- Markdownlint rule MD018 is disabled because standards entry points require
+  `#include` directives that are not valid ATX headings.
 
 ## Maintenance
+
 - Update the Table of Contents when headings change.
 - Keep documents current; stale guidance should be revised or removed.

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -71,8 +71,8 @@ explicitly state otherwise.
 - Markdownlint is the minimum baseline. Repositories may add additional checks.
 - Code repositories must document language-specific and repo-specific validation
   commands in their repository standards.
-- Markdownlint rule MD018 is disabled because standards entry points require
-  `#include` directives that are not valid ATX headings.
+- Include directives use HTML comments (`<!-- include: path -->`) so they do
+  not conflict with markdownlint.
 
 ## Maintenance
 

--- a/docs/foundation/overview.md
+++ b/docs/foundation/overview.md
@@ -1,20 +1,24 @@
 # Foundation Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Document map](#document-map)
 - [When to use each summary protocol](#when-to-use-each-summary-protocol)
 
 ## Purpose
+
 Provide a single entry point for foundational standards that apply across
 documentation, architecture, and AI-assisted work.
 
 ## Scope
+
 These standards define baseline expectations and protocols that other domains
 build upon.
 
 ## Document map
+
 - Markdown standards: [markdown-standards.md](markdown-standards.md)
 - Architecture standards: [architecture-standards.md](architecture-standards.md)
 - AI-assisted development loop: [ai-assisted-development-loop.md](ai-assisted-development-loop.md)
@@ -30,6 +34,7 @@ build upon.
 - Summarize stream of consciousness protocol: [summarize-stream-of-consciousness-protocol.md](summarize-stream-of-consciousness-protocol.md)
 
 ## When to use each summary protocol
+
 - Summarize stream of consciousness protocol: Use when capturing raw ideas in a
   toggleable capture window, then organizing them after `End SOC`.
 - Summarize decisions protocol: Use for discussions where the primary outcome

--- a/docs/foundation/summarize-decisions-protocol.md
+++ b/docs/foundation/summarize-decisions-protocol.md
@@ -1,6 +1,7 @@
 # Summarize decisions protocol
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
@@ -14,28 +15,36 @@
 - [Failure modes](#failure-modes)
 
 ## Purpose
+
 Define how to summarize a discussion into durable documentation that preserves
 decisions, reasoning, and alternatives.
 
 ## Scope
+
 Use this protocol for discussions intended for archival decision records.
 
 ## Definitions
+
 - Decision summary: the structured output produced by this protocol.
 - Input record: the chat or discussion content provided for summarization.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the protocol, such as:
+
 - `Summarize decisions`
 - `Decision summary`
 
 ## Input rules
+
 - Summaries MUST be based only on the input record.
 - External knowledge, assumptions, or inferred facts MUST NOT be added.
 - Missing or ambiguous information MUST be called out explicitly.
 
 ## Output structure
+
 The summary MUST follow this order:
+
 1. Results
 2. Reasoning
 3. Options not chosen
@@ -44,7 +53,9 @@ Additional sections MAY follow if they add clarity, but the order above MUST be
 preserved.
 
 ## Section requirements
+
 Results MUST include:
+
 - Decisions made
 - Deliverables or outputs agreed upon
 - Action items, with owners or roles if stated
@@ -53,6 +64,7 @@ Results MUST include:
 If no decisions were reached, Results MUST say so.
 
 Reasoning MUST include:
+
 - Key constraints or requirements
 - Assumptions that materially affect outcomes
 - Tradeoffs discussed and how they were resolved
@@ -62,6 +74,7 @@ Reasoning MUST include:
 If reasoning is incomplete or implicit, the summary MUST state that.
 
 Options not chosen MUST include:
+
 - Option description
 - Reasons it was not chosen
 - Status as rejected or deferred
@@ -70,8 +83,10 @@ Options not chosen MUST include:
 If no alternatives were discussed, Options not chosen MUST say so.
 
 ## Implicitly converged decisions
+
 Outcomes that are not explicitly declared but are clearly settled MAY be
 recorded as decisions only when:
+
 - The outcome is consistently supported by the Reasoning section.
 - No competing option remains actively defended.
 - Subsequent actions or conclusions depend on the outcome.
@@ -80,7 +95,9 @@ Such outcomes MUST be labeled as implicit or implicitly converged. If support
 is weak or ambiguous, record them as open questions instead.
 
 ## Optional sections
+
 Include only when discussed:
+
 - Risks and failure modes
 - Open questions
 - Dependencies or external constraints
@@ -88,11 +105,13 @@ Include only when discussed:
 - References to artifacts (files, commands, documents)
 
 ## Style and fidelity rules
+
 - The summary MUST be concise, structured, and non-narrative.
 - The summary MUST NOT introduce new decisions, claims, or rationales.
 - Ordering SHOULD mirror the original discussion when sequence matters.
 - The summary MUST distinguish facts from opinions or proposals.
 
 ## Failure modes
+
 - If the input record is missing or incomplete, the summary MUST note the gaps.
 - If results cannot be determined, the summary MUST say so explicitly.

--- a/docs/foundation/summarize-operations-protocol.md
+++ b/docs/foundation/summarize-operations-protocol.md
@@ -1,6 +1,7 @@
 # Summarize operations protocol
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
@@ -16,24 +17,30 @@
 - [Failure modes](#failure-modes)
 
 ## Purpose
+
 Define how to summarize operational work into durable documentation that
 preserves actions, outcomes, problems, and follow-up work.
 
 ## Scope
+
 Use this protocol for chats that perform operational procedures or system
 changes.
 
 ## Definitions
+
 - Operations summary: the structured output produced by this protocol.
 - Input record: the chat or discussion content provided for summarization.
 - Operational action: an action that changes system state or verifies it.
 
 ## Prompt shortcuts
+
 Use a standalone prompt that invokes the protocol, such as:
+
 - `Summarize operations`
 - `Ops summary`
 
 ## Input rules
+
 - Summaries MUST be based only on the input record.
 - External knowledge, assumptions, or inferred facts MUST NOT be added.
 - Missing or ambiguous information MUST be called out explicitly.
@@ -41,6 +48,7 @@ Use a standalone prompt that invokes the protocol, such as:
   the summary MUST note that sensitive data was redacted.
 
 ## Output location and naming
+
 When a repository or storage context exists, write the summary to the
 designated operations summary location and name the file with a UTC timestamp
 and short, lowercase, ASCII, kebab-case slug.
@@ -49,7 +57,9 @@ If no storage context exists, provide the summary directly in the response and
 note that no file was written.
 
 ## Output structure
+
 The summary MUST follow this order:
+
 1. Actions taken
 2. Outcomes and status
 3. Problems encountered and solved
@@ -61,7 +71,9 @@ Additional sections MAY follow if they add clarity, but the order above MUST be
 preserved.
 
 ## Section requirements
+
 Actions taken MUST:
+
 - List actions in the order performed.
 - Use clear, atomic statements in past tense.
 - Include timestamps when available.
@@ -71,6 +83,7 @@ Actions taken MUST:
 If no actions were taken, the summary MUST say so.
 
 Outcomes and status MUST:
+
 - State whether each action succeeded, failed, or is unknown.
 - Cite evidence from the input record (logs, tests, command output) when
   available.
@@ -79,6 +92,7 @@ Outcomes and status MUST:
 If success or failure is unclear, the summary MUST say it is unknown.
 
 Problems encountered and solved MUST include:
+
 - Symptoms or error messages
 - Root cause, if identified
 - Fix applied
@@ -86,6 +100,7 @@ Problems encountered and solved MUST include:
 If none were encountered or solved, the summary MUST say so.
 
 Problems unresolved is REQUIRED even if empty. It MUST include:
+
 - Current symptoms or failure mode
 - Impact or risk, if known
 - Attempts that failed
@@ -94,6 +109,7 @@ Problems unresolved is REQUIRED even if empty. It MUST include:
 If no unresolved problems remain, the summary MUST say so explicitly.
 
 Changes and artifacts MUST include:
+
 - Created, modified, or deleted resources
 - Configuration changes
 - Files or repositories changed
@@ -102,6 +118,7 @@ Changes and artifacts MUST include:
 If no changes were made, the summary MUST say so.
 
 Follow-up work and new issues MUST include:
+
 - Remaining steps or tasks
 - New issues discovered
 - Owners or roles if stated
@@ -110,12 +127,15 @@ Follow-up work and new issues MUST include:
 If none exist, the summary MUST say so.
 
 ## Evidence capture rules
+
 Operational summaries MUST include evidence for command-driven actions.
 At minimum, include:
+
 - The exact commands executed (flags and arguments included)
 - The relevant output that demonstrates success or failure
 
 Because output can be large, summaries MUST:
+
 - Include the smallest output snippet that proves the outcome.
 - Omit repetitive or verbose output unless it is the only evidence.
 - State when output is truncated and why.
@@ -125,7 +145,9 @@ Commands and outputs MUST NOT include secrets or credentials. If sensitive
 output exists, the summary MUST note that it was redacted.
 
 ## Timestamp requirements
+
 Summaries MUST capture available timestamps for:
+
 - Actions or grouped actions
 - Key outcomes or errors
 - Time zone or offset if known
@@ -134,7 +156,9 @@ If only relative timing is available, include it and note the lack of absolute
 time. If no timestamps are provided, the summary MUST say so.
 
 ## Optional sections
+
 Include only when discussed:
+
 - Verification or monitoring steps
 - Rollback or recovery notes
 - Risks and failure modes
@@ -142,6 +166,7 @@ Include only when discussed:
 - References to artifacts (files, commands, tickets)
 
 ## Style and fidelity rules
+
 - The summary MUST be concise, structured, and non-narrative.
 - The summary MUST NOT introduce new actions, outcomes, or causes.
 - Ordering SHOULD mirror the original sequence when it matters.
@@ -149,5 +174,6 @@ Include only when discussed:
 - Unresolved problems MUST be highlighted explicitly.
 
 ## Failure modes
+
 - If the input record is missing or incomplete, the summary MUST note the gaps.
 - If key outcomes cannot be determined, the summary MUST say so explicitly.

--- a/docs/foundation/summarize-stream-of-consciousness-protocol.md
+++ b/docs/foundation/summarize-stream-of-consciousness-protocol.md
@@ -1,6 +1,7 @@
 # Summarize stream of consciousness protocol
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Definitions](#definitions)
@@ -11,37 +12,46 @@
 - [Failure modes](#failure-modes)
 
 ## Purpose
+
 Define a toggleable protocol for capturing unfiltered, unstructured thoughts
 and organizing them into a durable summary after capture ends.
 
 ## Scope
+
 Use this protocol when raw idea capture is more valuable than immediate
 analysis, and the intent is to synthesize later into a structured artifact.
 
 ## Definitions
+
 - SOC session: the capture window between `Enter SOC` and `End SOC`.
 - Capture record: the ordered list of messages collected during a SOC session.
 - Trigger prompts: standalone messages that switch modes.
 
 ## Prompt shortcuts
+
 Use standalone prompts that invoke the protocol:
+
 - `Enter SOC` to begin capture.
 - `End SOC` to end capture.
 
 ## Protocol states
+
 The protocol is a two-state machine:
+
 - Idle: normal interaction and processing.
 - SOC capture: record-only mode.
 
 Transitions:
+
 - Idle to SOC capture on `Enter SOC`.
 - SOC capture to Idle on `End SOC`.
 - `Enter SOC` received during SOC capture is recorded as normal content.
 - `End SOC` received while Idle is treated as normal content.
- - The `Enter SOC` transition MUST be acknowledged with a confirmation that
+- The `Enter SOC` transition MUST be acknowledged with a confirmation that
    SOC capture mode is active.
 
 ## Capture rules
+
 - Trigger prompts MUST be standalone messages with exact text matching
   `Enter SOC` or `End SOC`.
 - During SOC capture, all messages MUST be recorded verbatim and in order.
@@ -53,21 +63,25 @@ Transitions:
   labels. Timestamps MAY be added if they are already available.
 
 ## Post-processing output
+
 After `End SOC`, produce a structured summary derived only from the capture
 record. Do not introduce new ideas. If inference is unavoidable, label it as
 inference.
 
 Required sections in order:
+
 - Summary: 1-3 sentences describing the overall thrust.
 - Themes: grouped bullets of related ideas.
 - Open questions: unresolved items or ambiguities.
 
 Optional sections (include only when non-empty):
+
 - Decisions
 - Action items
 - Outliers
 
 ## Failure modes
+
 - If a SOC session is not closed with `End SOC`, no summary is produced.
 - If capture artifacts are missing or corrupted, the summary MUST explicitly
   note the gaps and proceed only with the available content.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,6 +1,7 @@
 # Standards and Conventions Repository Standards
 
 ## Table of Contents
+
 - [AI co-authors](#ai-co-authors)
 - [Repository profile](#repository-profile)
 - [Validation policy](#validation-policy)
@@ -8,10 +9,12 @@
 - [Local deviations](#local-deviations)
 
 ## AI co-authors
+
 - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
 - Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
 
 ## Repository profile
+
 - repository_type: documentation
 - versioning_scheme: none
 - branching_model: docs-single-branch
@@ -19,11 +22,14 @@
 - supported_release_lines: none
 
 ## Validation policy
+
 - canonical_local_validation_command: scripts/lint/markdown-standards.sh
 - validation_required: yes (markdownlint required)
 
 ## CI gates
+
 Hard gates (required status checks on `develop`):
+
 - Standards compliance (`.github/workflows/standards-gates.yml`):
   - Repository profile validation (`scripts/lint/repo-profile.sh`)
   - Markdownlint (`scripts/lint/markdown-standards.sh`)
@@ -31,8 +37,11 @@ Hard gates (required status checks on `develop`):
   - Issue linkage validation (`scripts/lint/pr-issue-linkage.sh`)
 
 Local hard gates (pre-commit hooks):
-- Branch naming enforcement (`scripts/git-hooks/pre-commit`): require `feature/*` or `bugfix/*`.
+
+- Branch naming enforcement (`scripts/git-hooks/pre-commit`): require
+  `feature/*` or `bugfix/*`.
 - Commit message lint (`scripts/git-hooks/commit-msg`): Conventional Commits required.
 
 ## Local deviations
+
 - None.

--- a/docs/repository/overview.md
+++ b/docs/repository/overview.md
@@ -1,17 +1,21 @@
 # Repository Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Document Map](#document-map)
 
 ## Purpose
+
 Define reusable repository structure standards that keep projects durable,
 discoverable, and easy to operate without original authorship.
 
 ## Scope
+
 These standards apply to repository layout and documentation structure. They
 do not define language-specific coding practices.
 
 ## Document Map
+
 - Repository structure: [repository-structure.md](repository-structure.md)

--- a/docs/repository/repository-structure.md
+++ b/docs/repository/repository-structure.md
@@ -1,6 +1,7 @@
 # Repository Structure Standards
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Core Principles](#core-principles)
 - [Top-Level Layout](#top-level-layout)
@@ -10,10 +11,12 @@
 - [Revisiting the Structure](#revisiting-the-structure)
 
 ## Purpose
+
 Provide a default repository layout that is explicit, discoverable, and easy to
 maintain over time.
 
 ## Core Principles
+
 - Favor boring, explicit structure over cleverness.
 - Preserve survivability without original authorship.
 - Keep top-level organization shallow (no more than three levels deep at the
@@ -21,7 +24,9 @@ maintain over time.
 - Separate source code, tests, documentation, and tooling.
 
 ## Top-Level Layout
+
 Use the following directories by default:
+
 - `docs/`: documentation and standards
 - `docs/decisions/`: Architecture Decision Records (ADRs)
 - `src/`: production source code (when applicable)
@@ -34,24 +39,29 @@ Additional directories (for example, `infra/` or `deploy/`) are allowed when
 they are essential and clearly scoped.
 
 ## Tests
+
 Tests should mirror the `src/` layout as closely as practical. If the language
 uses a different convention, document the rationale and keep it consistent.
 
 ## Documentation and Decision Records
+
 Documentation lives under `docs/`.
 
 Use `docs/decisions/` for ADRs. Naming and structure:
+
 - Filenames: `NNNN-short-title.md` (zero-padded numeric prefix)
 - Required sections: Status, Context, Decision, Consequences
 - Keep the decision record immutable once accepted; revisions require a new
   ADR that references the original
 
 Each repository must include `docs/standards-and-conventions.md` that:
+
 - links to the canonical standards in this repository
 - documents project-specific overlays and deviations
 
 ## Examples
-```
+
+```text
 repo/
 ├── docs/
 │   ├── decisions/
@@ -69,5 +79,6 @@ repo/
 ```
 
 ## Revisiting the Structure
+
 If the repository structure becomes unclear or burdensome, record the change
 as a new ADR. Structure changes should be deliberate, not ad hoc.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -21,7 +21,8 @@ Every repository must include `docs/standards-and-conventions.md`.
 This file must:
 
 - reference the canonical standards in this repository using GitHub URLs or
-  by including the canonical standards entry point with `#include`
+  by including the canonical standards entry point with
+  `<!-- include: path -->`
 - make the required canonical references discoverable via a direct list or an
   include chain
 - document project-specific information and deviations inline or via
@@ -41,57 +42,57 @@ fatal exception and stop.
 
 This list is the authoritative include chain for the shared standards corpus.
 
-#include docs/foundation/overview.md
-#include docs/foundation/markdown-standards.md
-#include docs/foundation/architecture-standards.md
-#include docs/foundation/interaction-contract.md
-#include docs/foundation/interaction-contract-brief.md
-#include docs/foundation/ai-assisted-development-loop.md
-#include docs/foundation/ai-code-review-guidelines.md
-#include docs/foundation/agent-skills.md
-#include docs/foundation/agent-boot-banner.md
-#include docs/foundation/agent-pre-response-checklist.md
-#include docs/foundation/cognitive-drift-log.md
-#include docs/foundation/cognitive-regression-tests.md
-#include docs/foundation/summarize-decisions-protocol.md
-#include docs/foundation/summarize-operations-protocol.md
-#include docs/foundation/summarize-stream-of-consciousness-protocol.md
+<!-- include: docs/foundation/overview.md -->
+<!-- include: docs/foundation/markdown-standards.md -->
+<!-- include: docs/foundation/architecture-standards.md -->
+<!-- include: docs/foundation/interaction-contract.md -->
+<!-- include: docs/foundation/interaction-contract-brief.md -->
+<!-- include: docs/foundation/ai-assisted-development-loop.md -->
+<!-- include: docs/foundation/ai-code-review-guidelines.md -->
+<!-- include: docs/foundation/agent-skills.md -->
+<!-- include: docs/foundation/agent-boot-banner.md -->
+<!-- include: docs/foundation/agent-pre-response-checklist.md -->
+<!-- include: docs/foundation/cognitive-drift-log.md -->
+<!-- include: docs/foundation/cognitive-regression-tests.md -->
+<!-- include: docs/foundation/summarize-decisions-protocol.md -->
+<!-- include: docs/foundation/summarize-operations-protocol.md -->
+<!-- include: docs/foundation/summarize-stream-of-consciousness-protocol.md -->
 
-#include docs/code-management/overview.md
-#include docs/code-management/repository-types-and-attributes.md
-#include docs/code-management/commit-messages-and-authorship.md
-#include docs/code-management/github-issues.md
-#include docs/code-management/pull-request-workflow.md
-#include docs/code-management/source-control-guidelines.md
-#include docs/code-management/documentation-branching-model.md
-#include docs/code-management/branching-and-deployment.md
-#include docs/code-management/application-versioning-scheme.md
-#include docs/code-management/library-branching-and-release.md
-#include docs/code-management/library-versioning-scheme.md
-#include docs/code-management/release-versioning.md
-#include docs/code-management/hotfix-policy.md
-#include docs/code-management/shared-actions-library.md
+<!-- include: docs/code-management/overview.md -->
+<!-- include: docs/code-management/repository-types-and-attributes.md -->
+<!-- include: docs/code-management/commit-messages-and-authorship.md -->
+<!-- include: docs/code-management/github-issues.md -->
+<!-- include: docs/code-management/pull-request-workflow.md -->
+<!-- include: docs/code-management/source-control-guidelines.md -->
+<!-- include: docs/code-management/documentation-branching-model.md -->
+<!-- include: docs/code-management/branching-and-deployment.md -->
+<!-- include: docs/code-management/application-versioning-scheme.md -->
+<!-- include: docs/code-management/library-branching-and-release.md -->
+<!-- include: docs/code-management/library-versioning-scheme.md -->
+<!-- include: docs/code-management/release-versioning.md -->
+<!-- include: docs/code-management/hotfix-policy.md -->
+<!-- include: docs/code-management/shared-actions-library.md -->
 
-#include docs/repository/overview.md
-#include docs/repository/repository-structure.md
+<!-- include: docs/repository/overview.md -->
+<!-- include: docs/repository/repository-structure.md -->
 
-#include docs/dependencies/overview.md
-#include docs/dependencies/dependency-update-workflow.md
+<!-- include: docs/dependencies/overview.md -->
+<!-- include: docs/dependencies/dependency-update-workflow.md -->
 
-#include docs/development/overview.md
-#include docs/development/environment-and-tooling.md
-#include docs/development/deprecation-warnings.md
-#include docs/development/database/overview.md
-#include docs/development/database/conventions.md
-#include docs/development/python/overview.md
-#include docs/development/python/naming-conventions.md
-#include docs/development/python/type-hints.md
-#include docs/development/python/import-time-side-effects.md
-#include docs/development/python/testing-and-coverage.md
-#include docs/development/python/dependency-management.md
-#include docs/development/python/version-management.md
-#include docs/development/python/local-validation-scripts.md
-#include docs/development/python/ty-migration-plan.md
+<!-- include: docs/development/overview.md -->
+<!-- include: docs/development/environment-and-tooling.md -->
+<!-- include: docs/development/deprecation-warnings.md -->
+<!-- include: docs/development/database/overview.md -->
+<!-- include: docs/development/database/conventions.md -->
+<!-- include: docs/development/python/overview.md -->
+<!-- include: docs/development/python/naming-conventions.md -->
+<!-- include: docs/development/python/type-hints.md -->
+<!-- include: docs/development/python/import-time-side-effects.md -->
+<!-- include: docs/development/python/testing-and-coverage.md -->
+<!-- include: docs/development/python/dependency-management.md -->
+<!-- include: docs/development/python/version-management.md -->
+<!-- include: docs/development/python/local-validation-scripts.md -->
+<!-- include: docs/development/python/ty-migration-plan.md -->
 
 ## Project-specific overlay
 
@@ -113,7 +114,7 @@ included from `AGENTS.md` only. Do not include it here.
 ```text
 # <Repository> Standards Bootstrap
 
-  #include docs/standards-and-conventions.md
+  <!-- include: docs/standards-and-conventions.md -->
 ```
 
 ```text
@@ -124,7 +125,7 @@ included from `AGENTS.md` only. Do not include it here.
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-  #include ../standards-and-conventions/docs/standards-and-conventions.md
+  <!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
 
 ## Project-specific overlay
   See `docs/repository-standards.md` (included from `AGENTS.md`).

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,6 +1,7 @@
 # Standards and Conventions Reference
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Requirement](#requirement)
 - [Includes](#includes)
@@ -9,13 +10,16 @@
 - [Maintenance](#maintenance)
 
 ## Purpose
+
 Provide a required, repository-local entry point that references the canonical
 standards and documents project-specific details that do not belong upstream.
 
 ## Requirement
+
 Every repository must include `docs/standards-and-conventions.md`.
 
 This file must:
+
 - reference the canonical standards in this repository using GitHub URLs or
   by including the canonical standards entry point with `#include`
 - make the required canonical references discoverable via a direct list or an
@@ -34,6 +38,7 @@ If any required attribute is missing or left as a placeholder, treat it as a
 fatal exception and stop.
 
 ## Includes
+
 This list is the authoritative include chain for the shared standards corpus.
 
 #include docs/foundation/overview.md
@@ -89,7 +94,9 @@ This list is the authoritative include chain for the shared standards corpus.
 #include docs/development/python/ty-migration-plan.md
 
 ## Project-specific overlay
+
 Record project-specific details here, such as:
+
 - approved AI co-author identities for commit trailers
 - local terminology or naming conventions
 - approved deviations from canonical standards
@@ -102,13 +109,14 @@ Project-specific content must live in `docs/repository-standards.md` and be
 included from `AGENTS.md` only. Do not include it here.
 
 ## Template
-```
+
+```text
 # <Repository> Standards Bootstrap
 
   #include docs/standards-and-conventions.md
 ```
 
-```
+```text
 # <Repository> Standards and Conventions
 
 ## Table of Contents
@@ -122,7 +130,7 @@ included from `AGENTS.md` only. Do not include it here.
   See `docs/repository-standards.md` (included from `AGENTS.md`).
 ```
 
-```
+```text
 # <Repository> Repository Standards
 
 ## Table of Contents
@@ -145,5 +153,6 @@ included from `AGENTS.md` only. Do not include it here.
 ```
 
 ## Maintenance
+
 Keep this file short and current. Update it whenever a project-specific rule
 changes or a deviation is introduced or removed.

--- a/skills/context-bootstrap/SKILL.md
+++ b/skills/context-bootstrap/SKILL.md
@@ -65,11 +65,13 @@ Processing rules (exact):
   acting.
 
 ## Include syntax
-- Include lines must start with `#include` followed by a path.
+- Include lines must use HTML comments with the `include:` directive.
 - Accepted forms:
-  - `#include path`
-  - `#include "path"`
-  - `#include <path>`
+  - `<!-- include: path -->`
+  - `<!-- include: "path" -->`
+  - `<!-- include: <path> -->`
+- Legacy `#include` lines are supported for transition but must not be used in
+  new files.
 - Paths are treated as literal strings after stripping optional quotes or angle brackets.
 
 ## Include resolution (no inference)

--- a/skills/context-bootstrap/scripts/context_bootstrap_paths.py
+++ b/skills/context-bootstrap/scripts/context_bootstrap_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 STANDARDS_PREFIX = "../standards-and-conventions/"
 
@@ -30,6 +31,20 @@ def strip_include(raw: str) -> str:
     if raw.startswith("<") and raw.endswith(">"):
         return raw[1:-1]
     return raw
+
+
+def parse_include_line(line: str) -> str | None:
+    stripped = line.strip()
+    if stripped.startswith("#include") and len(stripped) > len("#include"):
+        remainder = stripped[len("#include") :].strip()
+        return strip_include(remainder)
+
+    if stripped.startswith("<!--") and stripped.endswith("-->"):
+        inner = stripped[4:-3].strip()
+        match = re.match(r"^include\\s*:\\s*(.+)$", inner, flags=re.IGNORECASE)
+        if match:
+            return strip_include(match.group(1).strip())
+    return None
 
 
 def read_text(path: str) -> str:
@@ -65,8 +80,8 @@ def resolve_include(repo_root: str, include_path: str) -> str | None:
 def iter_includes(content: str) -> list[str]:
     includes: list[str] = []
     for line in content.splitlines():
-        if line.startswith("#include ") or line.startswith("#include\t"):
-            include_path = strip_include(line[len("#include") :])
+        include_path = parse_include_line(line)
+        if include_path:
             includes.append(include_path)
     return includes
 


### PR DESCRIPTION
# Pull Request

## Summary
- switch include directives to HTML comments for markdownlint compatibility
- update context-bootstrap parser and skill docs to read the new syntax
- remove MD018 markdownlint exception

## Issue Linkage
- Fixes #113

## Testing
- scripts/lint/markdown-standards.sh

## Notes
- legacy `#include` syntax remains supported during transition.
