### PR TITLE
chore: require local markdownlint install

### DIFF
--- a/.github/workflows/standards-gates.yml
+++ b/.github/workflows/standards-gates.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Validate repository profile
         run: scripts/lint/repo-profile.sh
 
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+
       - name: Lint markdown standards
         run: scripts/lint/markdown-standards.sh
 

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -55,6 +55,12 @@ Recommended categories:
 Document versions where compatibility matters. Avoid adding tools without a
 clear justification.
 
+Tool installation is a human responsibility. Automation must not install or
+download external tooling on demand.
+
+Documentation repositories must include markdownlint in their external tooling
+list.
+
 ### Baseline automation assumptions
 
 For AI-assisted workflows in this environment, assume the following are

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -55,8 +55,9 @@ Recommended categories:
 Document versions where compatibility matters. Avoid adding tools without a
 clear justification.
 
-Tool installation is a human responsibility. Automation must not install or
-download external tooling on demand.
+Tool installation for local workflows is a human responsibility. Agents must
+not install or download external tooling on demand. CI workflows may provision
+required tools explicitly.
 
 Documentation repositories must include markdownlint in their external tooling
 list.

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -69,6 +69,8 @@ explicitly state otherwise.
 
 - All repositories must run markdownlint for documentation validation.
 - Markdownlint is the minimum baseline. Repositories may add additional checks.
+- Markdownlint must be installed locally by humans; automation must not
+  download or install it on demand.
 - Code repositories must document language-specific and repo-specific validation
   commands in their repository standards.
 - Include directives use HTML comments (`<!-- include: path -->`) so they do

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -69,8 +69,8 @@ explicitly state otherwise.
 
 - All repositories must run markdownlint for documentation validation.
 - Markdownlint is the minimum baseline. Repositories may add additional checks.
-- Markdownlint must be installed locally by humans; automation must not
-  download or install it on demand.
+- Markdownlint must be installed locally by humans; agents must not download or
+  install it on demand. CI workflows may provision it explicitly.
 - Code repositories must document language-specific and repo-specific validation
   commands in their repository standards.
 - Include directives use HTML comments (`<!-- include: path -->`) so they do

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -5,6 +5,7 @@
 - [AI co-authors](#ai-co-authors)
 - [Repository profile](#repository-profile)
 - [Validation policy](#validation-policy)
+- [External tooling dependencies](#external-tooling-dependencies)
 - [CI gates](#ci-gates)
 - [Local deviations](#local-deviations)
 
@@ -25,6 +26,10 @@
 
 - canonical_local_validation_command: scripts/lint/markdown-standards.sh
 - validation_required: yes (markdownlint required)
+
+## External tooling dependencies
+
+- markdownlint (markdownlint-cli)
 
 ## CI gates
 

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -26,10 +26,8 @@ fi
 
 if command -v markdownlint >/dev/null 2>&1; then
   markdownlint_cmd=(markdownlint)
-elif command -v npx >/dev/null 2>&1; then
-  markdownlint_cmd=(npx --yes markdownlint-cli)
 else
-  echo "ERROR: markdownlint not found. Install markdownlint-cli or ensure npx is available." >&2
+  echo "ERROR: markdownlint not found. Install markdownlint-cli locally." >&2
   exit 2
 fi
 


### PR DESCRIPTION
# Pull Request

## Summary
- remove the npx markdownlint fallback and require local installs
- document markdownlint in external tooling dependencies

## Issue Linkage
- Fixes #115

## Testing
- scripts/lint/markdown-standards.sh

## Notes
- tooling installation remains a human responsibility.
