### PR TITLE
docs: enforce uv-run python invocations

### DIFF
--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -30,7 +30,7 @@ Rules:
 
 - Use `python3` for all Python invocations. `python` is forbidden.
 - If `uv.lock` exists, invoke Python only as `uv run python3 ...`.
-  Direct `python3 ...` is forbidden in that case.
+  Direct `python3 ...` is forbidden in that case, except to install `uv`.
 - Treat a repository as Python if it contains `pyproject.toml`,
   `requirements*.txt`, `setup.cfg`, `setup.py`, or documentation that declares
   Python usage.

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -29,12 +29,16 @@ Rationale:
 Rules:
 
 - Use `python3` for all Python invocations. `python` is forbidden.
+- If `uv.lock` exists, invoke Python only as `uv run python3 ...`.
+  Direct `python3 ...` is forbidden in that case.
 - Treat a repository as Python if it contains `pyproject.toml`,
   `requirements*.txt`, `setup.cfg`, `setup.py`, or documentation that declares
   Python usage.
 - For Python repositories, activate the project-specific environment before
   running any Python command (application code, tests, utility scripts, or
   ad hoc invocations).
+- If `uv.lock` is missing in a Python repository, stop and treat the repository
+  as misconfigured before running Python commands.
 - If a Python repository does not define a project-specific environment, stop
   and establish one before running Python commands.
 - For non-Python repositories, do not assume Python is available. If Python is

--- a/docs/foundation/agent-guardrails.md
+++ b/docs/foundation/agent-guardrails.md
@@ -19,8 +19,9 @@ these standards.
 
 ## Guardrails
 
-- If `uv.lock` exists, all Python commands MUST run as `uv run python3 ...`.
-  If `uv.lock` is missing, stop and treat the repository as misconfigured.
+- If `uv.lock` exists, all Python commands MUST run as `uv run python3 ...`
+  (except installing `uv`). If `uv.lock` is missing, stop and treat the
+  repository as misconfigured.
 - If a prompt starts with `RTFM`, enter the RTFM protocol immediately and
   suspend normal work.
 - If on an eternal branch (`develop`, `release`, `main`), create a feature

--- a/docs/foundation/agent-guardrails.md
+++ b/docs/foundation/agent-guardrails.md
@@ -1,0 +1,32 @@
+# Agent guardrails
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Guardrails](#guardrails)
+- [Maintenance](#maintenance)
+
+## Purpose
+
+Provide a short, high-signal list of non-negotiable agent constraints that must
+be re-checked before taking action.
+
+## Scope
+
+Use before executing commands or making edits in any repository governed by
+these standards.
+
+## Guardrails
+
+- If `uv.lock` exists, all Python commands MUST run as `uv run python3 ...`.
+  If `uv.lock` is missing, stop and treat the repository as misconfigured.
+- If a prompt starts with `RTFM`, enter the RTFM protocol immediately and
+  suspend normal work.
+- If on an eternal branch (`develop`, `release`, `main`), create a feature
+  branch before any edits or commits.
+
+## Maintenance
+
+Keep this list short. Add items only when repeated failures show a hard
+non-negotiable rule needs a dedicated preflight gate.

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -26,6 +26,8 @@ Use before finalizing any response governed by the interaction contract.
   validation policy).
 - If context-bootstrap was run, the next response begins with the Standards
   Snapshot block.
+- Guardrails re-read before any command or edit
+  (`docs/foundation/agent-guardrails.md`).
 - Preflight gate emitted before any file edit or git action (branch, issue,
   docs-only scope, validation policy).
 - For documentation repositories, markdownlint is required. Do not ask for

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -51,6 +51,7 @@ This list is the authoritative include chain for the shared standards corpus.
 <!-- include: docs/foundation/ai-code-review-guidelines.md -->
 <!-- include: docs/foundation/agent-skills.md -->
 <!-- include: docs/foundation/agent-boot-banner.md -->
+<!-- include: docs/foundation/agent-guardrails.md -->
 <!-- include: docs/foundation/agent-pre-response-checklist.md -->
 <!-- include: docs/foundation/cognitive-drift-log.md -->
 <!-- include: docs/foundation/cognitive-regression-tests.md -->


### PR DESCRIPTION
## Summary
- Add a short guardrails doc and wire it into the canonical include chain.
- Require uv-run usage when uv.lock exists (bootstrap exception for installing uv).
- Add a checklist gate to re-read guardrails before commands.

## Testing
- scripts/lint/markdown-standards.sh
