### PR TITLE
docs: make finalization wait explicit

### DIFF
--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -202,10 +202,11 @@ merging.
 
 Finalize the PR in this order:
 
-1. merge the PR and delete the remote branch (or wait for auto-merge to do so)
-2. update local copy of the target branch
-3. synchronize the local environment with dependency specifications
-4. delete the local feature branch and prune stale remotes
-5. run final validation (skip for docs-only PRs)
+1. wait for all required checks to complete and pass
+2. merge the PR and delete the remote branch (or wait for auto-merge to do so)
+3. update local copy of the target branch
+4. synchronize the local environment with dependency specifications
+5. delete the local feature branch and prune stale remotes
+6. run final validation (skip for docs-only PRs)
 
 Do not reuse old branch names.

--- a/docs/code-management/workflow-runbooks.md
+++ b/docs/code-management/workflow-runbooks.md
@@ -74,11 +74,12 @@ Applies to all repositories governed by these standards.
 
 ## Pull request finalization runbook
 
-1. Wait for all required checks to pass.
-2. Merge the pull request and delete the remote branch.
-3. Update the local target branch.
-4. Delete the local feature branch and prune remotes.
-5. Run final validation unless the docs-only exception applies.
+1. Wait for all required checks to complete and pass.
+2. If auto-merge is enabled, wait for the merge to complete before cleanup.
+3. Merge the pull request (if not already merged) and delete the remote branch.
+4. Update the local target branch.
+5. Delete the local feature branch and prune remotes.
+6. Run final validation unless the docs-only exception applies.
 
 ## Docs-only exception runbook
 


### PR DESCRIPTION
# Pull Request

## Summary
- make finalization explicitly wait for required checks

## Issue Linkage
- Fixes #122

## Testing
- markdownlint (scripts/lint/markdown-standards.sh)

## Notes
- Docs-only: tests skipped
- Changed files: docs/code-management/pull-request-workflow.md; docs/code-management/workflow-runbooks.md
