### PR TITLE
docs: clarify finalize requires waiting

### DIFF
--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -179,6 +179,10 @@ Auto-merge is asynchronous. Enabling it is not finalization; you must still
 wait for required checks to complete. If any required check fails, fix the
 issue immediately and re-run the checks before merging.
 
+If the user asks to finalize a PR, waiting for auto-merge to complete is
+mandatory. Do not ask whether to wait unless the user explicitly requests a
+deferral.
+
 ## Async finalization guardrail
 
 Async submission requires a follow-up finalize step. To prevent "pending


### PR DESCRIPTION
# Pull Request

## Summary
- Clarify that finalization includes waiting for auto-merge to complete.
- Explicitly note that finalize should not prompt whether to wait.

## Issue Linkage
- Ref: not applicable

## Testing
- scripts/lint/markdown-standards.sh

## Notes
- Docs-only: tests skipped
