### PR TITLE
Docs: expand sovereignty research and number references

### DIFF
--- a/docs/research/eu-canada-github-aws-alternatives.md
+++ b/docs/research/eu-canada-github-aws-alternatives.md
@@ -6,6 +6,8 @@
 - [Scope and constraints](#scope-and-constraints)
 - [Evaluation criteria](#evaluation-criteria)
 - [Findings](#findings)
+  - [Sovereignty drivers and policy signal](#sovereignty-drivers-and-policy-signal)
+  - [US jurisdiction exposure and transfer risk](#us-jurisdiction-exposure-and-transfer-risk)
   - [Git hosting](#git-hosting)
   - [CI and CD](#ci-and-cd)
   - [Managed PostgreSQL and API hosting](#managed-postgresql-and-api-hosting)
@@ -39,8 +41,43 @@ Canada-based stack.
 - Viable CI/CD path without US-owned hosted runners.
 - Managed PostgreSQL availability.
 - Low operational overhead.
+- Jurisdictional exposure and transfer mechanisms; validate legal exposure and
+  exit options.
+- Contract transparency and switching expectations under the EU Data Act.
 
 ## Findings
+
+### Sovereignty drivers and policy signal
+
+- The European Commission launched a EUR 180 million tender (10 October 2025)
+  to procure sovereign cloud services for EU institutions under a Cloud
+  Sovereignty Framework. This is a clear policy signal and likely to shape
+  public-sector vendor requirements.[1]
+- The European Alliance for Industrial Data, Edge and Cloud is an EU-backed
+  initiative to strengthen European cloud and edge capabilities and define
+  investment roadmaps, reinforcing the political priority of EU-based
+  infrastructure.[2]
+- The EU Data Act (Regulation (EU) 2023/2854) applies from 12 September 2025
+  and introduces switching expectations for cloud services, including minimum
+  cloud contract requirements and safeguards against unlawful third-country
+  access to non-personal data held in the EU.[3] [4]
+- In the current political climate, European governments are actively reducing
+  reliance on U.S. tech providers. France announced that 2.5 million civil
+  servants will move off U.S. video-conferencing tools by 2027 in favor of a
+  domestic platform, and other public bodies are shifting to open-source
+  alternatives to reduce dependency.[5]
+
+### US jurisdiction exposure and transfer risk
+
+- The U.S. CLOUD Act allows U.S. courts to compel U.S. providers to disclose
+  data in their possession, custody, or control regardless of where it is
+  stored. US-owned vendors therefore create jurisdictional exposure even with
+  EU or Canadian data residency.[6]
+- The EU-U.S. Data Privacy Framework adequacy decision (2023/1795) allows
+  transfers of EU personal data to U.S. organizations on the DPF list and
+  requires ongoing Commission monitoring. The EDPB welcomed improvements but
+  flagged concerns about scope, onward transfers, bulk collection, and
+  redress.[7] [8]
 
 ### Git hosting
 
@@ -49,42 +86,42 @@ Canada-based stack.
   services run on their own hardware in Berlin, with some tasks offloaded to
   netcup and Hetzner for redundancy and backups, and that they avoid large
   cloud providers where possible. It is Forgejo-based and offers additional
-  services like hosted CI. This fits the non-US-ownership requirement.
+  services like hosted CI. This fits the non-US-ownership requirement.[9] [10]
 - Codeberg offers Forgejo Actions but hosts Actions only in limited fashion
   due to security and staffing constraints. It recommends Woodpecker CI if
-  you need hosted CI, and supports connecting your own runners.
+  you need hosted CI, and supports connecting your own runners.[11]
 - Forgejo Actions is designed to be familiar to GitHub Actions but is not
-  compatible; minor workflow changes are expected.
+  compatible; minor workflow changes are expected.[12]
 - Worktree stores data in Canada and documents that Git, LFS, attachments,
   packages, and related services run on OVH bare metal in Montreal, with
-  backups in OVH Toronto. It lists Actions as running on AWS Montreal.
+  backups in OVH Toronto. It lists Actions as running on AWS Montreal.[13]
   The Worktree Actions launch post says workflows run on DigitalOcean Toronto.
   Both AWS and DigitalOcean are US-owned, so hosted Actions currently conflict
-  with the non-US-ownership requirement.
+  with the non-US-ownership requirement.[13] [14]
 
 ### CI and CD
 
 - Codeberg can run CI with Woodpecker or with self-hosted Forgejo Actions
-  runners; hosted Actions are limited.
+  runners; hosted Actions are limited.[11]
 - Worktree Actions is GitHub Actions-compatible, but the documented execution
   layer is on US-owned infrastructure (AWS Montreal and/or DigitalOcean
   Toronto), so self-hosted runners or an alternate CI system are required
-  to meet the ownership constraint.
+  to meet the ownership constraint.[13] [14]
 
 ### Managed PostgreSQL and API hosting
 
 - Scaleway provides a managed PostgreSQL service and is a Paris-registered
   company. Managed PostgreSQL is available in the Paris, Amsterdam, and
-  Warsaw regions.
+  Warsaw regions.[15] [16] [17]
 - OVHcloud offers managed PostgreSQL (DBaaS) on its public cloud, with a
   Canada-specific offering documented on its OVHcloud Canada site. Use this if
   you need DBaaS convenience, and verify ownership and region availability as
-  part of due diligence.
+  part of due diligence.[18]
 - IONOS provides DBaaS for PostgreSQL with managed features (backups, scaling,
-  monitoring) and states that DBaaS is offered in all IONOS Cloud locations.
+  monitoring) and states that DBaaS is offered in all IONOS Cloud locations.[19]
 - ThinkOn positions itself as a 100% Canadian-owned and operated sovereign
   cloud. It is a strong fit for Canadian ownership but does not document a
-  managed PostgreSQL service in the referenced material.
+  managed PostgreSQL service in the referenced material.[20]
 
 ## Recommendations
 
@@ -139,28 +176,44 @@ PostgreSQL). This increases operational effort but meets the ownership bar.
 
 ## Risks and open questions
 
+- If any US-owned services remain in the stack, document CLOUD Act exposure and
+  apply strong contractual and technical controls (encryption, key ownership).[6]
 - Codeberg hosted Actions are limited; use Woodpecker or self-hosted runners
-  if you need stable CI capacity.
+  if you need stable CI capacity.[11]
 - Worktree hosted Actions currently run on US-owned infrastructure (AWS or
   DigitalOcean). This conflicts with the non-US-ownership requirement unless
-  you run your own runners.
+  you run your own runners.[13] [14]
 - Codeberg storage limits exist; confirm that repository and LFS usage fits
-  within current quotas or request exceptions.
+  within current quotas or request exceptions.[21]
 - Validate vendor subprocessors (billing, monitoring, support) before
   commitment, since ownership and data residency can be affected by them.
+- Ensure vendor contracts and exit plans reflect EU Data Act requirements on
+  switching and contract transparency; obligations apply from 12 September
+  2025.[3] [4]
+- If you rely on the EU-U.S. Data Privacy Framework for any data transfers,
+  confirm vendor certification status and track regulatory changes, as the
+  framework is subject to ongoing monitoring and has unresolved concerns.[7] [8]
 
 ## References
 
-- [Codeberg FAQ (hosting location and infrastructure)](https://docs.codeberg.org/getting-started/faq/)
-- [Codeberg overview (organization and services)](https://docs.codeberg.org/getting-started/what-is-codeberg/)
-- [Codeberg Actions (self-hosted runners and hosted Actions limits)](https://docs.codeberg.org/ci/actions/)
-- [Forgejo Actions compatibility notes](https://forgejo.org/docs/v12.0/user/actions/github-actions/)
-- [Worktree data sovereignty (provider list)](https://docs.worktree.ca/sovereignty/)
-- [Worktree Actions launch (execution environment)](https://about.worktree.ca/blog/2025-03-07-worktree-actions/)
-- [Scaleway legal notice](https://www.scaleway.com/en/legal-notice/)
-- [Scaleway managed PostgreSQL docs](https://www.scaleway.com/en/docs/managed-databases-for-postgresql-and-mysql/)
-- [Scaleway managed PostgreSQL regions (API)](https://www.scaleway.com/en/developers/api/managed-databases-for-postgresql-and-mysql/)
-- [OVHcloud public cloud PostgreSQL (Canada)](https://www.ovhcloud.com/fr-ca/public-cloud/postgresql/)
-- [IONOS PostgreSQL DBaaS overview](https://docs.ionos.com/cloud/databases/postgresql/overview)
-- [ThinkOn data sovereignty overview (Canadian ownership)](https://thinkon.com/resources/data-sovereignty-myth/)
-- [Codeberg storage limits (quotas)](https://blog.codeberg.org/new-storage-limits-on-codeberg-what-you-need-to-know.html)
+[1]: <https://commission.europa.eu/news-and-media/news/commission-moves-forward-cloud-sovereignty-eur-180-million-tender-2025-10-10_en>
+[2]: <https://digital-strategy.ec.europa.eu/en/policies/cloud-alliance>
+[3]: <https://eur-lex.europa.eu/eli/reg/2023/2854>
+[4]: <https://digital-strategy.ec.europa.eu/en/news/european-data-act-enters-force-putting-place-new-rules-fair-and-innovative-data-economy>
+[5]: <https://apnews.com/article/europe-digital-sovereignty-big-tech-9f5388b68a0648514cebc8d92f682060>
+[6]: <https://www.congress.gov/crs-product/LSB10125>
+[7]: <https://eur-lex.europa.eu/eli/dec_impl/2023/1795/>
+[8]: <https://www.edpb.europa.eu/news/news/2023/edpb-welcomes-improvements-under-eu-us-data-privacy-framework-concerns-remain_en>
+[9]: <https://docs.codeberg.org/getting-started/what-is-codeberg/>
+[10]: <https://docs.codeberg.org/getting-started/faq/>
+[11]: <https://docs.codeberg.org/ci/actions/>
+[12]: <https://forgejo.org/docs/v12.0/user/actions/github-actions/>
+[13]: <https://docs.worktree.ca/sovereignty/>
+[14]: <https://about.worktree.ca/blog/2025-03-07-worktree-actions/>
+[15]: <https://www.scaleway.com/en/legal-notice/>
+[16]: <https://www.scaleway.com/en/docs/managed-databases-for-postgresql-and-mysql/>
+[17]: <https://www.scaleway.com/en/developers/api/managed-databases-for-postgresql-and-mysql/>
+[18]: <https://www.ovhcloud.com/fr-ca/public-cloud/postgresql/>
+[19]: <https://docs.ionos.com/cloud/databases/postgresql/overview>
+[20]: <https://thinkon.com/resources/data-sovereignty-myth/>
+[21]: <https://blog.codeberg.org/new-storage-limits-on-codeberg-what-you-need-to-know.html>


### PR DESCRIPTION
# Pull Request\n\n## Summary\n- Add sovereignty policy signal and US jurisdiction risk context to the EU/Canada alternatives report.\n- Convert references to numbered inline citations for consistency.\n\n## Issue Linkage\n- Fixes #128\n\n## Testing\n- scripts/lint/markdown-standards.sh\n\n## Notes\n- Docs-only: tests skipped\n- Files changed:\n  - docs/research/eu-canada-github-aws-alternatives.md