### PR TITLE
docs: convert RTFM protocol to a skill

### DIFF
--- a/docs/code-management/workflow-runbooks.md
+++ b/docs/code-management/workflow-runbooks.md
@@ -29,7 +29,7 @@ Applies to all repositories governed by these standards.
 2. Record the standards snapshot before any action.
 3. Check for open pull requests targeting the primary integration branch. If
    any are merged but not finalized, finalize them before starting new work.
-4. If a prompt starts with `RTFM`, enter the RTFM protocol and suspend normal
+4. If a prompt starts with `RTFM`, invoke the `rtfm` skill and suspend normal
    work.
 
 ## Issue creation runbook

--- a/docs/foundation/agent-guardrails.md
+++ b/docs/foundation/agent-guardrails.md
@@ -22,7 +22,7 @@ these standards.
 - If `uv.lock` exists, all Python commands MUST run as `uv run python3 ...`
   (except installing `uv`). If `uv.lock` is missing, stop and treat the
   repository as misconfigured.
-- If a prompt starts with `RTFM`, enter the RTFM protocol immediately and
+- If a prompt starts with `RTFM`, invoke the `rtfm` skill immediately and
   suspend normal work.
 - Standards bootstrap is `AGENTS.md` only; do not run include-resolution
   scripts or use bootstrap skills.

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -20,7 +20,7 @@ Use before finalizing any response governed by the interaction contract.
 
 - Problem constraints are explicit.
 - Assumptions are stated.
-- If the prompt starts with `RTFM`, switch to the RTFM protocol and suspend
+- If the prompt starts with `RTFM`, invoke the `rtfm` skill and suspend
   normal work.
 - Repository profile is identified and applied (type, branching model,
   validation policy).

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,6 +31,8 @@ Skill bodies must remain aligned with the canonical documents they reference.
   workflow with failure handling and anchor rules.
 - `deprecation-triage` (`skills/deprecation-triage/SKILL.md`): deprecation
   warning triage workflow and issue template.
+- `rtfm` (`skills/rtfm/SKILL.md`): RTFM forced interruption handling with
+  failure context capture and issue tracking.
 
 ## Usage conventions
 - Keep skills minimal and procedural; defer rationale to the standards.

--- a/skills/rtfm/SKILL.md
+++ b/skills/rtfm/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: rtfm
+description: Handle RTFM forced interruptions by capturing failure context, identifying violated standards, and creating a tracking issue.
+---
+
+# RTFM protocol
+
+## Table of Contents
+- [Overview](#overview)
+- [Inputs](#inputs)
+- [Workflow](#workflow)
+- [Issue template](#issue-template)
+- [Resources](#resources)
+
+## Overview
+RTFM is a forced interruption that indicates a standards violation or a missed
+requirement that should have been clear from the governing documentation. Pause
+all other work and complete this workflow before resuming normal work.
+
+## Inputs
+Collect from the triggering message and session context:
+- Optional reason provided after `RTFM` (hint about the violated standards)
+- Current branch and git status
+- Files touched and action sequence that triggered the violation
+
+## Workflow
+1. Pause all other work immediately.
+2. Capture the failure context with concrete evidence (branch, git status,
+   files touched, and the action sequence that triggered the violation).
+3. Identify the violated standards with exact document paths and section
+   headings, and state how the response diverged.
+4. Ask the user what was unclear or insufficient in the standards; use the
+   optional reason to focus the question.
+5. Create a GitHub issue in the current repository using the template below.
+6. Propose and, when feasible, implement documentation updates that prevent
+   recurrence before resuming normal work.
+
+## Issue template
+```
+Title: RTFM: <short failure summary>
+
+Violated standard(s):
+- document path:
+- section:
+
+Failure context:
+- branch:
+- git status:
+- files touched:
+- action sequence:
+
+What was unclear:
+<description of the documentation gap or ambiguity>
+
+Missing or bypassed gate:
+<the check or guardrail that should have prevented this>
+
+Proposed documentation update:
+<specific changes to prevent recurrence>
+```
+
+Label: `rtfm`
+
+## Resources
+- `docs/foundation/interaction-contract.md` (RTFM protocol section)
+- `docs/foundation/agent-guardrails.md`
+- `docs/foundation/agent-pre-response-checklist.md`


### PR DESCRIPTION
Fixes #133

## Summary
- Add `skills/rtfm/SKILL.md` with the RTFM forced-interruption workflow and issue template
- Update `agent-guardrails.md`, `agent-pre-response-checklist.md`, and `workflow-runbooks.md` to invoke the `rtfm` skill instead of referencing "the RTFM protocol"
- Register the new skill in `skills/README.md`

## Test plan
- [x] Docs-only change — no local validation required

🤖 Generated with [Claude Code](https://claude.com/claude-code)