### PR TITLE
docs: add Java development standards

### DIFF
--- a/docs/development/java/naming-conventions.md
+++ b/docs/development/java/naming-conventions.md
@@ -1,0 +1,228 @@
+# Java Naming Conventions
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Google Java Style Guide Baseline](#google-java-style-guide-baseline)
+- [Casing Convention Note](#casing-convention-note)
+- [Variable Naming Rules](#variable-naming-rules)
+  - [1. Class-to-Variable Mapping](#1-class-to-variable-mapping)
+  - [2. Minimum Length: 3+ Characters](#2-minimum-length-3-characters)
+  - [3. Complete English Words](#3-complete-english-words)
+  - [4. Namespace Collision Handling](#4-namespace-collision-handling)
+  - [5. Boolean Variables](#5-boolean-variables)
+  - [6. Collections: Plural vs. Singular](#6-collections-plural-vs-singular)
+  - [7. Consistency Rules](#7-consistency-rules)
+
+## Purpose
+
+Provide naming rules that optimize for clarity, consistency, and accessibility.
+
+## Google Java Style Guide Baseline
+
+Follow the Google Java Style Guide as the default:
+
+- Classes, interfaces, enums, records, annotations: `PascalCase`
+- Methods, variables, parameters: `camelCase`
+- Constants (`static final` immutable values): `UPPER_SNAKE_CASE`
+- Packages: all lowercase, no underscores
+- Type parameters: single uppercase letter (`T`, `E`, `K`, `V`) or
+  `PascalCase` with a `T` suffix (`RequestT`, `ResponseT`)
+- Private or internal fields: no prefix (no `m` prefix, no leading underscore)
+
+## Casing Convention Note
+
+The variable naming rules below are adapted from Damian Conway's "Perl Best
+Practices" (2005). Conway's original rules assume `snake_case` for all
+identifiers. Java's 30+ year ecosystem convention uses `camelCase` for
+variables, methods, and parameters. Where Conway specifies casing, Java's
+`camelCase` convention takes precedence without exception. Conway's underlying
+principles (descriptive names, minimum length, complete words, grammatical
+consistency) are fully adopted.
+
+## Variable Naming Rules
+
+These rules are based on Damian Conway's "Perl Best Practices" (2005), adapted
+for Java and validated over long-term use.
+
+### 1. Class-to-Variable Mapping
+
+Variables representing a class instance use the `camelCase` version of the
+class name.
+
+```java
+// Correct
+Instrument instrument = new Instrument();
+ExerciseState exerciseState = new ExerciseState();
+PracticeBlock practiceBlock = new PracticeBlock();
+
+// Wrong
+Instrument inst = new Instrument();
+ExerciseState exState = new ExerciseState();
+PracticeBlock block = new PracticeBlock();
+```
+
+### 2. Minimum Length: 3+ Characters
+
+One- and two-character variable names are prohibited because they reduce
+readability and accessibility.
+
+```java
+// Correct
+for (int index = 0; index < 10; index++) {
+    Instrument instrument = instruments.get(index);
+}
+
+int count = instruments.size();
+for (int instrumentIndex = 0; instrumentIndex < count; instrumentIndex++) {
+    process(instruments.get(instrumentIndex));
+}
+
+// Wrong
+for (int i = 0; i < 10; i++) {
+    Instrument x = xs.get(i);
+}
+```
+
+Exceptions:
+
+- Well-established mathematical variables in limited scope (`x`, `y` for a
+  five-line coordinate algorithm).
+- Common domain abbreviations used across a codebase may appear as tokens:
+  `id`, `db`, `api`, `env`, `app`. Use these only as clear tokens
+  (for example, `instrumentId`, `dbSession`, `apiRouter`, `envName`,
+  `appState`), not as single-character loop variables.
+- Enum member names may use short domain codes (for example, `F0`) when those
+  codes are established labels.
+
+### 3. Complete English Words
+
+Use complete English words, not abbreviations.
+
+```java
+// Correct
+RuntimeException exception = new RuntimeException();
+Configuration configuration = loadConfiguration();
+Session databaseSession = getSession();
+int instrumentIndex = 0;
+
+// Wrong
+RuntimeException exc = new RuntimeException();
+Configuration config = loadConfiguration();  // Use configuration
+Session db = getSession();                   // Use databaseSession
+int idx = 0;                                 // Use index or instrumentIndex
+```
+
+Exception: allowed domain abbreviations (for example, `id`, `db`, `api`) may
+appear as tokens in identifiers. Other acronyms are acceptable only when they
+are official domain terms (for example, `UTC`) and should not be shortened
+further.
+
+### 4. Namespace Collision Handling
+
+When multiple classes share a name, disambiguate with descriptive prefixes.
+
+```java
+// Correct
+import org.hibernate.Session;
+import javax.servlet.http.HttpSession;
+
+Session dbSession = sessionFactory.openSession();
+HttpSession httpSession = request.getSession();
+
+// Wrong
+import org.hibernate.Session;
+
+Session sess = sessionFactory.openSession();
+Object session2 = request.getSession();
+```
+
+Collision prefixes are chosen contextually (for example, `db`, `http`, `rest`).
+
+### 5. Boolean Variables
+
+Boolean variables should read like questions. This aligns naturally with
+JavaBeans conventions for boolean property accessors.
+
+- `is*`: state or condition (`isValid`, `isEmpty`, `isActive`)
+- `has*`: possession or presence (`hasPermission`, `hasItems`, `hasError`)
+- `can*`: capability or permission (`canDelete`, `canWrite`, `canEdit`)
+
+```java
+// Correct
+boolean isValid = validate(instrument);
+boolean hasPermission = checkAccess(user);
+boolean canDelete = user.isAdmin() || resource.getOwner().equals(user);
+
+if (isValid && hasPermission && canDelete) {
+    delete(resource);
+}
+
+// Wrong
+boolean valid = validate(instrument);
+boolean permission = checkAccess(user);
+boolean deletable = user.isAdmin();
+```
+
+### 6. Collections: Plural vs. Singular
+
+Name collections based on how they are primarily used.
+
+Plural for collective processing:
+
+```java
+List<Instrument> instruments = query.getResultList();
+for (Instrument instrument : instruments) {
+    process(instrument);
+}
+
+List<Long> exerciseIds = exercises.stream()
+    .map(Exercise::getId)
+    .collect(Collectors.toList());
+```
+
+Singular for individual access (lookup tables):
+
+```java
+Map<Long, Instrument> instrumentById = instruments.stream()
+    .collect(Collectors.toMap(Instrument::getId, Function.identity()));
+Instrument instrument = instrumentById.get(42L);
+
+Map<String, Exercise> exerciseByName = new HashMap<>();
+Exercise exercise = exerciseByName.get("Chromatic Scale");
+```
+
+### 7. Consistency Rules
+
+- Syntactic consistency: if one variable uses `adjectiveNoun`, all similar
+  variables use `adjectiveNoun`.
+- Semantic consistency: names convey what data represents, not just its type.
+- Cross-codebase consistency: the same concept uses the same name everywhere.
+
+```java
+// Correct
+public Instrument createInstrument(String name) {
+    Instrument instrument = new Instrument(name);
+    dbSession.persist(instrument);
+    return instrument;
+}
+
+public Instrument updateInstrument(Instrument instrument, String name) {
+    instrument.setName(name);
+    dbSession.flush();
+    return instrument;
+}
+
+// Wrong
+public Instrument createInstrument(String name) {
+    Instrument inst = new Instrument(name);
+    dbSession.persist(inst);
+    return inst;
+}
+
+public Instrument updateInstrument(Instrument instrument, String name) {
+    instrument.setName(name);
+    dbSession.flush();
+    return instrument;
+}
+```

--- a/docs/development/java/overview.md
+++ b/docs/development/java/overview.md
@@ -1,0 +1,69 @@
+# Java Coding Standards Overview
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Core Principles](#core-principles)
+- [Tooling Expectations](#tooling-expectations)
+- [CI Gates](#ci-gates)
+- [Document Map](#document-map)
+
+## Purpose
+
+Define consistent Java standards that emphasize readability, maintainability,
+and long-term survivability across repositories.
+
+## Core Principles
+
+- Google Java Style Guide compliance is the default and highest priority.
+- Readability overrides cleverness or brevity.
+- Exceptions must be explicit, documented, and justified.
+
+## Tooling Expectations
+
+- Formatting: google-java-format (opinionated, zero configuration).
+- Style enforcement: Checkstyle with the Google checks configuration.
+- Static analysis: SpotBugs (bytecode-level bug detection) and PMD
+  (source-level bug detection).
+- Compiler plugin: Error Prone (catches common mistakes at compile time).
+- Null safety: NullAway (Error Prone plugin, low-overhead null checks).
+- Build system: project-dependent (Maven or Gradle). Document the choice and
+  equivalent commands in the repository README.
+- If a repository uses different tools, document the reason and equivalents.
+
+## CI Gates
+
+Every CI check is classified as a hard gate or soft gate.
+
+Hard gate definition:
+
+- Merge-blocking. A required status check must be configured on the target
+  branch. Any failure blocks merge until a new commit passes.
+
+Soft gate definition:
+
+- Warning-only. The check can fail without blocking merge, but failures must be
+  surfaced with rationale and follow-up tracking when applicable.
+
+Hard gates (all are required status checks):
+
+- `test-and-validate (current)`
+- `integration-tests`
+- `dependency-audit`
+
+Soft gates:
+
+- None (default to hard gate until documented).
+
+Branch applicability:
+
+- develop: all hard gates required
+- release: all hard gates required
+- main: all hard gates required
+
+Docs-only pull requests may skip these jobs when the repository implements the
+docs-only CI skip policy.
+
+## Document Map
+
+- Naming conventions: [naming-conventions.md](naming-conventions.md)


### PR DESCRIPTION
## Summary

- Add Java coding standards overview (`docs/development/java/overview.md`) covering core principles, tooling expectations, CI gates, and document map
- Add Java naming conventions (`docs/development/java/naming-conventions.md`) with Google Java Style Guide baseline and all seven Conway-adapted variable naming rules
- Follows the pattern established by the Python development standards

Docs-only: tests skipped

Files changed:
- `docs/development/java/overview.md` (new)
- `docs/development/java/naming-conventions.md` (new)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
