### PR TITLE
docs: relax boolean naming convention to recommendation

### DIFF
--- a/docs/development/java/naming-conventions.md
+++ b/docs/development/java/naming-conventions.md
@@ -141,15 +141,16 @@ Collision prefixes are chosen contextually (for example, `db`, `http`, `rest`).
 
 ### 5. Boolean Variables
 
-Boolean variables should read like questions. This aligns naturally with
-JavaBeans conventions for boolean property accessors.
+Prefer `is*`, `has*`, or `can*` prefixes when they make the name read more
+naturally as a true/false condition. This aligns with JavaBeans conventions
+for boolean property accessors.
 
 - `is*`: state or condition (`isValid`, `isEmpty`, `isActive`)
 - `has*`: possession or presence (`hasPermission`, `hasItems`, `hasError`)
 - `can*`: capability or permission (`canDelete`, `canWrite`, `canEdit`)
 
 ```java
-// Correct
+// Prefixes improve clarity — use them
 boolean isValid = validate(instrument);
 boolean hasPermission = checkAccess(user);
 boolean canDelete = user.isAdmin() || resource.getOwner().equals(user);
@@ -157,11 +158,27 @@ boolean canDelete = user.isAdmin() || resource.getOwner().equals(user);
 if (isValid && hasPermission && canDelete) {
     delete(resource);
 }
+```
 
-// Wrong
-boolean valid = validate(instrument);
-boolean permission = checkAccess(user);
-boolean deletable = user.isAdmin();
+Omit the prefix when the name already reads unambiguously as a boolean
+without it. Names that are verbs, verb phrases, or adjective phrases often
+convey boolean intent on their own:
+
+```java
+// Already clear without a prefix
+boolean verifyTls = true;
+boolean mapAttributes = true;
+boolean strict = true;
+```
+
+Avoid bare nouns or adjectives that could be mistaken for the thing itself
+rather than a condition about it:
+
+```java
+// Ambiguous without a prefix
+boolean valid = validate(instrument);       // Use isValid
+boolean permission = checkAccess(user);     // Use hasPermission
+boolean deletable = user.isAdmin();         // Use canDelete
 ```
 
 ### 6. Collections: Plural vs. Singular

--- a/docs/development/python/naming-conventions.md
+++ b/docs/development/python/naming-conventions.md
@@ -126,25 +126,42 @@ Collision prefixes are chosen contextually (for example, `DB`, `REST`).
 
 ### 5. Boolean Variables
 
-Boolean variables should read like questions:
+Prefer `is_*`, `has_*`, or `can_*` prefixes when they make the name read more
+naturally as a true/false condition:
 
 - `is_*`: state or condition (`is_valid`, `is_empty`, `is_active`)
 - `has_*`: possession or presence (`has_permission`, `has_items`, `has_error`)
 - `can_*`: capability or permission (`can_delete`, `can_write`, `can_edit`)
 
 ```python
-# Correct
+# Prefixes improve clarity — use them
 is_valid = validate(instrument)
 has_permission = check_access(user)
 can_delete = user.is_admin or resource.owner == user
 
 if is_valid and has_permission and can_delete:
     delete(resource)
+```
 
-# Wrong
-valid = validate(instrument)
-permission = check_access(user)
-deletable = ...
+Omit the prefix when the name already reads unambiguously as a boolean without
+it. Names that are verbs, verb phrases, or adjective phrases often convey
+boolean intent on their own:
+
+```python
+# Already clear without a prefix
+verify_tls = True
+map_attributes = True
+strict = True
+```
+
+Avoid bare nouns or adjectives that could be mistaken for the thing itself
+rather than a condition about it:
+
+```python
+# Ambiguous without a prefix
+valid = validate(instrument)       # Use is_valid
+permission = check_access(user)    # Use has_permission
+deletable = ...                    # Use can_delete
 ```
 
 ### 6. Collections: Plural vs. Singular


### PR DESCRIPTION
## Summary

- Demote boolean `is_`/`has_`/`can_` prefix from hard requirement to recommendation in both Python and Java naming conventions
- Add three-tier guidance: use prefixes when they improve clarity, omit when redundant, avoid ambiguous bare nouns
- Motivated by gap analyses of pymqrest ([pymqrest#226](https://github.com/wphillipmoore/pymqrest/issues/226)) and mq-rest-admin ([mq-rest-admin#17](https://github.com/wphillipmoore/mq-rest-admin/issues/17))

Docs-only: tests skipped

Files changed:
- `docs/development/python/naming-conventions.md`
- `docs/development/java/naming-conventions.md`

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
