### PR TITLE
docs: specify exact issue linkage format in pr-workflow skill

### DIFF
--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -38,7 +38,10 @@ Follow local overrides (AGENTS or repo-specific standards) when present.
 2. If no canonical command exists, ask for the required validation steps.
 3. If any check fails, do not submit the PR; fix and rerun the full checks.
 4. Populate the pull request template fields.
-5. Include issue linkage when required.
+5. Include issue linkage using `Fixes #N` (default; auto-closes issue on
+   merge) or `Ref #N` (non-closing; use when acceptance criteria exist).
+   These are the only accepted keywords — `Closes`, `Resolves`, and other
+   GitHub keywords are rejected by CI.
 
 ## Submission and finalization
 - Submit the PR only after all required checks pass (unless docs-only


### PR DESCRIPTION
## Summary

Fixes #143

The pr-workflow skill said "Include issue linkage when required" without
specifying the accepted format. The `pr-issue-linkage.sh` lint script only
accepts `Fixes #N` or `Ref #N`, rejecting other GitHub keywords like `Closes`
and `Resolves`.

Updates step 5 in the Pre-submission steps to explicitly list:
- `Fixes #N` — default, auto-closes issue on merge
- `Ref #N` — non-closing, for issues with acceptance criteria
- All other keywords (`Closes`, `Resolves`, etc.) are rejected by CI

Docs-only: tests skipped

Files changed:
- `skills/pr-workflow/SKILL.md`

## Test plan

- [ ] Verify skill text is clear and unambiguous
- [ ] Confirm `~/.claude/skills/pr-workflow/SKILL.md` stays in sync