### PR TITLE
docs: add cross-language runtime version support policy

### DIFF
--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -11,8 +11,6 @@
   - [Boundary Rule](#boundary-rule)
   - [Explicit Non-Decision](#explicit-non-decision)
 - [4. Runtime Version Policy](#4-runtime-version-policy)
-  - [Supported Versions](#supported-versions)
-  - [CI Requirements](#ci-requirements)
   - [Deployment Rule](#deployment-rule)
 - [5. CI/CD Constraints](#5-cicd-constraints)
   - [CI gates](#ci-gates)
@@ -106,14 +104,8 @@ This decision may be revisited once:
 
 ## 4. Runtime Version Policy
 
-### Supported Versions
-
-- The current stable language runtime version is the default target.
-- Additional versions must be explicitly listed and justified.
-
-### CI Requirements
-
-CI pipelines must validate against the current stable runtime version.
+For tier definitions, CI matrix classification, and drop criteria, see the
+[Runtime Version Support Policy](../development/runtime-version-support-policy.md).
 
 ### Deployment Rule
 

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -18,7 +18,10 @@ platform-specific conventions.
 ## Document Map
 
 - Environment and tooling: [environment-and-tooling.md](environment-and-tooling.md)
+- Runtime version support policy:
+  [runtime-version-support-policy.md](runtime-version-support-policy.md)
 - Python standards: [python/overview.md](python/overview.md)
+- Java standards: [java/overview.md](java/overview.md)
 - Database standards: [database/overview.md](database/overview.md)
 - Shell scripting standards: [shell/overview.md](shell/overview.md)
 - Deprecation warning policy: [deprecation-warnings.md](deprecation-warnings.md)

--- a/docs/development/python/version-management.md
+++ b/docs/development/python/version-management.md
@@ -76,27 +76,29 @@ When the next Python minor series transitions from pre-release to bugfix
 
 1. At the start of the next development cycle, add the next minor version to
    the CI matrix.
-2. Label CI jobs by role: `current`, `next`, and (when applicable) `previous`.
-3. Keep the `current` minor version as the only hard gate. The `next` minor
-   check is advisory and must not block merges.
-4. Record any failures in the next minor check and track them as issues, but
-   do not block PRs unless the current minor fails.
+2. Label CI jobs using the runtime version support policy convention:
+   `bugfix-<version>`, `preview-<version>`, and (when applicable)
+   `security-<version>`.
+3. Keep `bugfix-<version>` jobs as the only hard gate. The
+   `preview-<version>` check is advisory and must not block merges.
+4. Record any failures in the preview check and track them as issues, but do
+   not block PRs unless a bugfix-tier job fails.
 
 ### Cutover criteria
 
-Promote the next minor version to current only after it has been stable in CI
-for at least two full development cycles.
+Promote the preview version to bugfix tier only after it has been stable in
+CI for at least two full development cycles.
 
 At the start of the next development cycle after meeting the stability
 threshold:
 
 1. Update the canonical Python version to the new minor series.
-2. Make the new minor the required (hard-gate) CI runtime and label it as
-   `current`.
-3. Demote the prior `current` minor to `previous` and keep it advisory to
-   preserve rollback capability.
-4. Keep `previous` advisory until humans explicitly decide to drop it. Do not
-   auto-remove `previous` based on elapsed cycles alone.
+2. Make the new minor the required (hard-gate) CI runtime and relabel it as
+   `bugfix-<version>`.
+3. Relabel the prior bugfix minor as `security-<version>` and keep it
+   advisory to preserve rollback capability.
+4. Keep `security-<version>` advisory until humans explicitly decide to drop
+   it. Do not auto-remove based on elapsed cycles alone.
 
 ### Stability tracking
 
@@ -104,9 +106,9 @@ Once dual-CI begins, record stability status at the start of each development
 cycle. Capture:
 
 - cycle start date
-- current minor version
-- candidate minor version (`next`)
-- prior minor version (`previous`, if retained)
+- bugfix-tier minor version
+- preview-tier minor version (candidate for promotion)
+- security-tier minor version (if retained)
 - CI status summary and any open issues blocking promotion
 
 Store the stability log in a repository-local doc (for example,
@@ -153,5 +155,7 @@ CI must fail when:
 
 ## Related documents
 
+- Runtime version support policy:
+  [runtime-version-support-policy.md](../runtime-version-support-policy.md)
 - Python dependency management: [dependency-management.md](dependency-management.md)
 - Dependency anchor records: [dependency anchor records](../../dependencies/overview.md)

--- a/docs/development/runtime-version-support-policy.md
+++ b/docs/development/runtime-version-support-policy.md
@@ -1,0 +1,197 @@
+# Runtime Version Support Policy
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Definitions](#definitions)
+- [Support tiers](#support-tiers)
+- [CI matrix mapping](#ci-matrix-mapping)
+- [Application versus library scope](#application-versus-library-scope)
+- [Drop criteria](#drop-criteria)
+- [Drop procedure](#drop-procedure)
+- [Language lifecycle references](#language-lifecycle-references)
+- [Related documents](#related-documents)
+
+## Purpose
+
+Define a tiered runtime version support policy that balances forward progress
+with consumer compatibility. This policy provides cross-language guidance for
+which runtime versions to test, which CI results block merges, and when to drop
+a version.
+
+## Scope
+
+Applies to all repositories that declare a language runtime dependency (Python,
+Java, Go, or any other language with discrete runtime releases). This policy
+complements language-specific upgrade workflows such as the Python version
+management standard; it does not replace them.
+
+## Definitions
+
+- **GA release**: A production-ready version published through the language's
+  official release channel.
+- **Active bugfix**: A GA release series receiving regular bug fixes and
+  security patches from the upstream maintainer.
+- **Security-fix-only**: A GA release series receiving only critical security
+  patches, with no further bug fixes.
+- **EOL (end of life)**: A release series no longer receiving any patches from
+  the upstream maintainer.
+- **Hard gate**: A CI check that blocks PR merge when it fails.
+- **Soft gate**: A CI check that surfaces warnings but does not block PR merge.
+  Failures must be documented in the PR with rationale and any follow-up
+  tracking.
+- **Advisory**: A CI check run for informational purposes only. Failures are
+  logged but carry no merge or follow-up obligations.
+
+## Support tiers
+
+Each runtime version in a CI matrix must be assigned to exactly one tier.
+
+### Tier 1 — active bugfix
+
+The primary supported version. This is the version used for development,
+deployment, and release artifacts.
+
+- Gate type: hard gate (blocking).
+- All tests and validation checks must pass.
+- Production deployments use a Tier 1 version.
+
+### Tier 2 — next development release
+
+The upcoming version that has entered GA but has not yet been promoted to the
+primary development version.
+
+- Gate type: soft gate (non-blocking).
+- Failures are tracked as issues but do not block PRs.
+- Purpose: early detection of incompatibilities before the next version becomes
+  Tier 1.
+
+### Tier 3 — security-fix-only
+
+A prior version still receiving security patches from the upstream maintainer.
+Relevant primarily for libraries that must support consumers on older runtimes.
+
+- Gate type: hard gate while the version remains supportable.
+- Dropped when continued support inhibits forward progress (see
+  [Drop criteria](#drop-criteria)).
+
+### Tier 4 — EOL
+
+A version that has reached end of life upstream.
+
+- Gate type: advisory (best-effort).
+- Failures are logged but never block merges.
+- Do not invest effort maintaining compatibility with EOL versions.
+
+## CI matrix mapping
+
+| Tier | CI job label | Gate type | Merge impact |
+| --- | --- | --- | --- |
+| 1 — active bugfix | `bugfix-<version>` | Hard gate | Blocks merge |
+| 2 — next development | `preview-<version>` | Soft gate | Warning only |
+| 3 — security-fix-only | `security-<version>` | Hard gate | Blocks merge |
+| 4 — EOL | `eol-<version>` | Advisory | No impact |
+
+Every label includes the version because each tier may contain more than one
+version simultaneously.
+
+Each repository must document its CI matrix with tier assignments in its
+repository standards or CI configuration.
+
+## Application versus library scope
+
+### Applications
+
+Applications target a single runtime version (Tier 1). They do not maintain
+backward compatibility with older runtimes.
+
+- CI matrix: Tier 1 only, plus optionally Tier 2 for forward-looking testing.
+- Production deployments always use the Tier 1 version.
+
+### Libraries
+
+Libraries test against all Tier 1 versions and conditionally against Tier 3
+versions to support consumers on older runtimes.
+
+- CI matrix: Tier 1 (hard gate), Tier 3 if consumers require it (hard gate),
+  Tier 2 (soft gate).
+- Tier 4 is advisory and included only when the cost is negligible.
+
+## Drop criteria
+
+A runtime version should be considered for removal from the CI matrix when any
+of the following conditions apply:
+
+- Supporting the version requires pinning dependencies to older versions that
+  block upgrades for other supported versions.
+- Maintaining compatibility shims or conditional code paths that degrade
+  readability or test coverage.
+- Continued support prevents adopting language features or library APIs that
+  benefit all other supported versions.
+- The upstream maintainer has moved the version to EOL status.
+
+A single criterion is sufficient justification to begin the drop procedure.
+
+## Drop procedure
+
+1. **Open an issue** documenting which version is being dropped and the
+   evidence supporting the decision (reference the applicable drop criteria).
+2. **Update the CI matrix** to remove the version or reclassify it to Tier 4
+   (advisory) as an intermediate step.
+3. **Update build configuration** to remove any compatibility shims, conditional
+   code paths, or pinned dependencies that existed solely to support the
+   dropped version.
+4. **Add a release note** entry (or changelog entry, per the repository's
+   versioning scheme) stating the minimum supported runtime version.
+5. **Update repository documentation** (repository standards, README, or
+   equivalent) to reflect the new minimum version.
+
+## Language lifecycle references
+
+These summaries describe how major languages classify their release phases.
+Use them to map upstream status to the tier definitions above.
+
+### Python
+
+Python uses three lifecycle phases per minor release:
+
+- **Bugfix** (approximately 18 months after GA): active bugfix releases.
+  Maps to Tier 1 or Tier 2.
+- **Security** (approximately 3.5 years after bugfix phase ends): security
+  patches only. Maps to Tier 3.
+- **EOL**: no further patches. Maps to Tier 4.
+
+Reference: Python Developer's Guide, Status of Python Versions.
+
+### Java
+
+Java release lifecycle varies by distribution:
+
+- **LTS releases** (for example, 17, 21): extended support from the
+  distribution vendor. Typically maps to Tier 1 or Tier 3 depending on
+  the project's adoption timeline.
+- **Non-LTS releases**: short support windows (six months). Typically map to
+  Tier 2 for forward-looking testing only.
+
+Determine support commitment based on the distribution's published support
+schedule, not the OpenJDK upstream alone.
+
+### Go
+
+Go supports the two most recent major releases:
+
+- **Current release**: maps to Tier 1.
+- **Previous release**: maps to Tier 3 (still receiving security patches).
+- **Older releases**: maps to Tier 4 (EOL).
+
+Reference: Go Release Policy.
+
+## Related documents
+
+- Python version management:
+  [version-management.md](python/version-management.md)
+- Deprecation warning policy:
+  [deprecation-warnings.md](deprecation-warnings.md)
+- Source code management guidelines:
+  [source-control-guidelines.md](../code-management/source-control-guidelines.md)

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -84,6 +84,7 @@ This list is the authoritative include chain for the shared standards corpus.
 
 <!-- include: docs/development/overview.md -->
 <!-- include: docs/development/environment-and-tooling.md -->
+<!-- include: docs/development/runtime-version-support-policy.md -->
 <!-- include: docs/development/deprecation-warnings.md -->
 <!-- include: docs/development/database/overview.md -->
 <!-- include: docs/development/database/conventions.md -->


### PR DESCRIPTION
## Summary

- Add `docs/development/runtime-version-support-policy.md` defining four support tiers (active bugfix, next development, security-fix-only, EOL) with CI gate classification, drop criteria, drop procedure, and language lifecycle references for Python, Java, and Go
- Replace inline version policy in `source-control-guidelines.md` with a reference to the new document, preserving the deployment rule and invariant
- Align Python `version-management.md` CI job labels to the new `bugfix-<version>`/`preview-<version>`/`security-<version>`/`eol-<version>` naming convention
- Add runtime version support policy to the development overview document map and the standards include chain
- Add Java standards entry (already existed, was missing from overview)

Closes #145

Docs-only: tests skipped

Files changed:
- `docs/development/runtime-version-support-policy.md` (new)
- `docs/development/overview.md`
- `docs/code-management/source-control-guidelines.md`
- `docs/development/python/version-management.md`
- `docs/standards-and-conventions.md`

## Test plan

- [x] `scripts/lint/markdown-standards.sh` passes
- [ ] Review tier definitions match issue #145 requirements
- [ ] Review CI job label naming convention (`bugfix-`/`preview-`/`security-`/`eol-` with version suffix)
- [ ] Verify cross-references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
