### PR TITLE
docs: exempt doc-site pages from TOC requirement

### DIFF
--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -44,6 +44,9 @@ explicitly state otherwise.
 - List all `##` and `###` headings in order, excluding the Table of Contents.
 - Use a bullet list with two-space indentation for `###` entries.
 - Use GitHub-style anchor links.
+- **Exception**: Pages built by documentation site generators (Sphinx, MkDocs,
+  etc.) are exempt from the Table of Contents requirement because those tools
+  provide integrated navigation.
 
 ## Formatting Conventions
 


### PR DESCRIPTION
## Summary
- Adds exception to Table of Contents rules for pages built by documentation site generators (Sphinx, MkDocs, etc.)
- These tools provide integrated navigation, making inline TOC sections redundant

## Issue Linkage
- No issue — minor standards clarification that unblocks doc-site work across the mq-rest-admin family

## Notes
- Companion PR in standard-actions updates the CI enforcement script

Docs-only: tests skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)