### PR TITLE
docs: add missing Table of Contents to documentation-toolchain.md

### DIFF
--- a/docs/development/documentation-toolchain.md
+++ b/docs/development/documentation-toolchain.md
@@ -1,5 +1,15 @@
 # Documentation Toolchain
 
+## Table of Contents
+
+- [Decision](#decision)
+- [Status](#status)
+- [Context](#context)
+- [Comparison](#comparison)
+- [Rationale](#rationale)
+- [Required Configuration](#required-configuration)
+- [Shared Fragment Architecture](#shared-fragment-architecture)
+
 ## Decision
 
 All library repositories in the mq-rest-admin family use **MkDocs Material** as


### PR DESCRIPTION
Fixes #159

## Summary

- Add required `## Table of Contents` section to `docs/development/documentation-toolchain.md` that was missed in #157

## Test plan

- [ ] `standards-compliance` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)