### PR TITLE
Add GitHub Pages doctree with MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Documentation
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Standards and Conventions
+
+## Table of Contents
+
+- [Sections](#sections)
+
+## Sections
+
+This site is the canonical reference for development standards,
+conventions, and workflows. All repositories reference these
+standards as their baseline.
+
+- **[Foundation](foundation/overview.md)** — Markdown standards,
+  architecture patterns, interaction contracts, and AI agent
+  guidelines
+- **[Code Management](code-management/overview.md)** — Branching
+  models, commit messages, pull requests, versioning, and releases
+- **[Repository](repository/overview.md)** — Repository structure
+  and organization standards
+- **[Dependencies](dependencies/overview.md)** — Dependency
+  management and update workflows
+- **[Development](development/overview.md)** — Language-specific
+  standards (Python, Go, Java, Shell) and cross-cutting concerns
+- **[Research](research/eu-canada-github-aws-alternatives.md)** —
+  Research reports and evaluations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,120 @@
+site_name: Standards and Conventions
+site_description: Canonical standards and conventions reference
+repo_url: https://github.com/wphillipmoore/standards-and-conventions
+repo_name: wphillipmoore/standards-and-conventions
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+
+nav:
+  - Home: index.md
+  - Foundation:
+      - Overview: foundation/overview.md
+      - Markdown Standards: foundation/markdown-standards.md
+      - Architecture Standards: foundation/architecture-standards.md
+      - Interaction Contract: foundation/interaction-contract.md
+      - Interaction Contract (Brief): foundation/interaction-contract-brief.md
+      - AI-Assisted Development Loop: foundation/ai-assisted-development-loop.md
+      - AI Code Review Guidelines: foundation/ai-code-review-guidelines.md
+      - Agent Boot Banner: foundation/agent-boot-banner.md
+      - Agent Guardrails: foundation/agent-guardrails.md
+      - Agent Pre-Response Checklist: foundation/agent-pre-response-checklist.md
+      - Agent Skills: foundation/agent-skills.md
+      - Standards Bootstrap Protocol: foundation/standards-bootstrap-protocol.md
+      - Cognitive Drift Log: foundation/cognitive-drift-log.md
+      - Cognitive Regression Tests: foundation/cognitive-regression-tests.md
+      - Summarize Decisions Protocol: foundation/summarize-decisions-protocol.md
+      - Summarize Operations Protocol: foundation/summarize-operations-protocol.md
+      - Summarize SOC Protocol: foundation/summarize-stream-of-consciousness-protocol.md
+  - Code Management:
+      - Overview: code-management/overview.md
+      - Source Control Guidelines: code-management/source-control-guidelines.md
+      - Branching and Deployment: code-management/branching-and-deployment.md
+      - Documentation Branching Model: code-management/documentation-branching-model.md
+      - Library Branching and Release: code-management/library-branching-and-release.md
+      - Commit Messages and Authorship: code-management/commit-messages-and-authorship.md
+      - Pull Request Workflow: code-management/pull-request-workflow.md
+      - GitHub Issues: code-management/github-issues.md
+      - Hotfix Policy: code-management/hotfix-policy.md
+      - Application Versioning Scheme: code-management/application-versioning-scheme.md
+      - Library Versioning Scheme: code-management/library-versioning-scheme.md
+      - Release and Versioning Policy: code-management/release-versioning.md
+      - Repository Types and Attributes: code-management/repository-types-and-attributes.md
+      - Shared Actions Library: code-management/shared-actions-library.md
+      - Workflow Runbooks: code-management/workflow-runbooks.md
+  - Repository:
+      - Overview: repository/overview.md
+      - Repository Structure: repository/repository-structure.md
+  - Dependencies:
+      - Overview: dependencies/overview.md
+      - Dependency Update Workflow: dependencies/dependency-update-workflow.md
+  - Development:
+      - Overview: development/overview.md
+      - Environment and Tooling: development/environment-and-tooling.md
+      - Documentation Toolchain: development/documentation-toolchain.md
+      - Deprecation Warnings: development/deprecation-warnings.md
+      - Runtime Version Support Policy: development/runtime-version-support-policy.md
+      - Python:
+          - Overview: development/python/overview.md
+          - Naming Conventions: development/python/naming-conventions.md
+          - Type Hints: development/python/type-hints.md
+          - Dependency Management: development/python/dependency-management.md
+          - Testing and Coverage: development/python/testing-and-coverage.md
+          - Import-Time Side Effects: development/python/import-time-side-effects.md
+          - Local Validation Scripts: development/python/local-validation-scripts.md
+          - Version Management: development/python/version-management.md
+          - Ty Migration Plan: development/python/ty-migration-plan.md
+      - Go:
+          - Overview: development/go/overview.md
+          - Naming Conventions: development/go/naming-conventions.md
+      - Java:
+          - Overview: development/java/overview.md
+          - Naming Conventions: development/java/naming-conventions.md
+      - Shell:
+          - Overview: development/shell/overview.md
+          - Naming Conventions: development/shell/naming-conventions.md
+      - Database:
+          - Overview: development/database/overview.md
+          - Conventions: development/database/conventions.md
+  - Research:
+      - EU/Canada Alternatives: research/eu-canada-github-aws-alternatives.md


### PR DESCRIPTION
## Summary

- Add `mkdocs.yml` with Material theme, full nav tree covering all docs sections, and markdown extensions
- Add `docs/index.md` as the site landing page with section quick links
- Add `.github/workflows/docs.yml` to deploy to GitHub Pages on push to `develop`

Docs-only: tests skipped

**Files changed:** `mkdocs.yml`, `docs/index.md`, `.github/workflows/docs.yml`

Fixes #162

## Test plan

- [x] `mkdocs build --strict` succeeds locally
- [x] `scripts/lint/markdown-standards.sh` passes
- [ ] After merge, confirm GH Actions workflow runs on `develop`
- [ ] Configure repo Settings > Pages to serve from `gh-pages` branch
- [ ] Verify site is live at `https://wphillipmoore.github.io/standards-and-conventions/`