### PR TITLE
docs: convert to MkDocs/mike publication workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+      - run: pip install mkdocs-material mike
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Determine version
+        id: version
+        run: |
+          echo "version=dev" >> "$GITHUB_OUTPUT"
+          echo "alias=latest" >> "$GITHUB_OUTPUT"
+      - name: Deploy with mike
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ALIAS: ${{ steps.version.outputs.alias }}
+        run: |
+          mike deploy --push --update-aliases \
+            "$VERSION" "$ALIAS"
+          mike set-default --push latest

--- a/docs/development/documentation-toolchain.md
+++ b/docs/development/documentation-toolchain.md
@@ -8,33 +8,34 @@
 - [Comparison](#comparison)
 - [Rationale](#rationale)
 - [Required Configuration](#required-configuration)
+- [CI Workflow Pattern](#ci-workflow-pattern)
 - [Shared Fragment Architecture](#shared-fragment-architecture)
 
 ## Decision
 
-All library repositories in the mq-rest-admin family use **MkDocs Material** as
-the documentation toolchain. This applies to every language port (Python, Java,
-Go, and any future additions).
+All repositories use **MkDocs Material** with **mike** versioning as the
+documentation toolchain. This applies to documentation-only repositories,
+application repositories, and library repositories across all languages.
 
 ## Status
 
 **Adopted** — February 2026.
 
-- mq-rest-admin-java: MkDocs Material (adopted at project inception)
-- mq-rest-admin-python: MkDocs Material (migrated from Sphinx+MyST+Furo)
-- mq-rest-admin-go: MkDocs Material (adopted at project inception)
+- standards-and-conventions: MkDocs Material + mike (documentation-only repo)
+- mq-rest-admin-java: MkDocs Material + mike (adopted at project inception)
+- mq-rest-admin-python: MkDocs Material + mike (migrated from Sphinx+MyST+Furo)
+- mq-rest-admin-go: MkDocs Material + mike (adopted at project inception)
 
 ## Context
 
-The mq-rest-admin library family spans multiple languages. Each repo contains
-substantial narrative documentation (architecture, mapping pipeline, ensure/sync
-methods, design rationale) that is largely identical across repos. Sharing this
-content requires a common documentation toolchain with a snippet inclusion
-mechanism.
+A consistent documentation toolchain across all repositories provides a uniform
+reading experience, versioned documentation tied to releases, searchable
+published sites, and the ability to share documentation fragments between
+repositories that use common content.
 
-The Python repo originally used Sphinx with MyST-Parser and the Furo theme.
-The Java repo adopted MkDocs Material from inception. This divergence prevented
-sharing documentation fragments via the `mq-rest-admin-common` repository.
+The Python ecosystem originally used Sphinx with MyST-Parser and the Furo theme.
+Standardizing on MkDocs Material eliminated the toolchain divergence and enabled
+documentation fragment sharing via `pymdownx.snippets`.
 
 ## Comparison
 
@@ -52,31 +53,64 @@ sharing documentation fragments via the `mq-rest-admin-common` repository.
 | Admonitions | Built-in | Built-in |
 | Build speed | Moderate | Fast |
 | Config complexity | `conf.py` + extensions | Single `mkdocs.yml` |
-| Cross-repo sharing | Manual duplication | `pymdownx.snippets` base paths |
+| Versioned docs | `sphinx-multiversion` | mike |
 
 ## Rationale
 
-1. **Shared content**: `pymdownx.snippets` enables all repos to include
-   narrative fragments from `mq-rest-admin-common/fragments/` without
-   duplication. This is the primary driver.
+1. **Consistent experience**: Identical theme, navigation structure, and
+   feature set across all documentation sites regardless of repository type
+   or language.
 
-2. **Consistent experience**: Identical theme, navigation structure, and
-   feature set across all library documentation sites.
+2. **Versioned documentation**: mike provides versioned documentation tied
+   to branches and releases, with a version selector in the published site.
 
-3. **Simpler maintenance**: One `mkdocs.yml` per repo versus Sphinx's
+3. **Shared content**: `pymdownx.snippets` enables repositories to include
+   narrative fragments from shared repositories without duplication.
+
+4. **Simpler maintenance**: One `mkdocs.yml` per repo versus Sphinx's
    `conf.py` plus multiple extension configurations.
 
-4. **No capability loss**: `mkdocstrings[python]` provides equivalent
+5. **No capability loss**: `mkdocstrings[python]` provides equivalent
    autodoc functionality for Python. Java uses Javadoc separately.
-   Every Sphinx feature used by the Python docs has a direct MkDocs
-   Material equivalent.
+   Every Sphinx feature used has a direct MkDocs Material equivalent.
 
 ## Required Configuration
 
-### mkdocs.yml structure
+### Repository layout patterns
 
-All repos use `docs/site/mkdocs.yml` with `docs_dir: docs` (content lives
-in `docs/site/docs/`).
+Two layout patterns exist based on repository type:
+
+| Repository type | mkdocs.yml location | docs_dir | Content path |
+| --- | --- | --- | --- |
+| Documentation-only | repo root | `docs` | `docs/` |
+| Code repositories | `docs/site/mkdocs.yml` | `docs` | `docs/site/docs/` |
+
+Documentation-only repositories (like standards-and-conventions) place
+`mkdocs.yml` at the repository root with content in `docs/`. Code repositories
+nest the MkDocs configuration under `docs/site/` to keep documentation
+separate from source code.
+
+### mike configuration (all repos)
+
+Every repository must include these settings in `mkdocs.yml`:
+
+```yaml
+strict: true
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
+```
+
+- `strict: true` causes the build to fail on warnings, catching broken links
+  and missing references in CI.
+- `extra.version.provider: mike` enables the version selector in the Material
+  theme.
+- `plugins: [search]` explicitly enables search (required when specifying the
+  plugins list).
 
 ### Theme
 
@@ -116,22 +150,14 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.snippets:
-      base_path:
-        - docs
-        - ../../.mq-rest-admin-common/fragments
-        - ../../../mq-rest-admin-common/fragments
+  - pymdownx.snippets
   - tables
   - toc:
       permalink: true
 ```
 
-The `pymdownx.snippets` base paths resolve in two contexts:
-
-- **CI**: `../../.mq-rest-admin-common/fragments` (common repo checked out
-  at `.mq-rest-admin-common` in the workspace root)
-- **Local**: `../../../mq-rest-admin-common/fragments` (sibling directory
-  at `~/dev/github/mq-rest-admin-common`)
+Repositories that share documentation fragments via `pymdownx.snippets` add
+`base_path` entries to resolve fragment locations in both CI and local contexts.
 
 ### Language-specific plugins
 
@@ -155,28 +181,123 @@ plugins:
 
 **Go repos** use standard Go doc tooling (no mkdocstrings equivalent).
 
-### CI workflow
+## CI Workflow Pattern
 
-All repos check out `mq-rest-admin-common` in the docs workflow:
+All repositories use a GitHub Actions workflow that deploys documentation with
+mike. The workflow structure adapts to the repository's branching model.
+
+### Standard workflow structure
 
 ```yaml
-- name: Checkout mq-rest-admin-common
-  uses: actions/checkout@v4
-  with:
-    repository: wphillipmoore/mq-rest-admin-common
-    ref: develop
-    path: .mq-rest-admin-common
+name: Documentation
+
+on:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material mike
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Determine version
+        id: version
+        run: |
+          # Version determination varies by branching model (see below)
+      - name: Deploy with mike
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ALIAS: ${{ steps.version.outputs.alias }}
+        run: |
+          mike deploy --push --update-aliases \
+            "$VERSION" "$ALIAS"
+          mike set-default --push latest
 ```
+
+Key requirements:
+
+- `fetch-depth: 0` is required for mike to access the `gh-pages` branch
+  history.
+- Git identity must be configured before mike can push.
+- `concurrency` prevents parallel deployments from conflicting.
+
+### Version determination by branching model
+
+#### docs-single-branch
+
+Documentation-only repositories use `develop` as the single eternal branch.
+Since there is no `main` branch, `develop` represents the canonical state:
+
+```yaml
+- name: Determine version
+  id: version
+  run: |
+    echo "version=dev" >> "$GITHUB_OUTPUT"
+    echo "alias=latest" >> "$GITHUB_OUTPUT"
+```
+
+The workflow triggers only on `develop` pushes. The `dev` version always
+receives the `latest` alias since it is the only published version.
+
+#### application-promotion and library-release
+
+Repositories with both `develop` and `main` branches determine the version
+from the branch:
+
+```yaml
+- name: Determine version
+  id: version
+  run: |
+    if [ "${{ github.ref_name }}" = "main" ]; then
+      VERSION=$(cat VERSION)
+      echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      echo "alias=latest" >> "$GITHUB_OUTPUT"
+    else
+      echo "version=dev" >> "$GITHUB_OUTPUT"
+      echo "alias=" >> "$GITHUB_OUTPUT"
+    fi
+```
+
+- `main` branch: version from `VERSION` file, aliased as `latest`.
+- `develop` branch: version `dev`, no alias.
+
+The workflow triggers on both `develop` and `main` pushes.
 
 ## Shared Fragment Architecture
 
-Narrative content shared across repos lives in
-`mq-rest-admin-common/fragments/`. Each repo includes these fragments
-using `pymdownx.snippets`:
+Repositories that share documentation content use `pymdownx.snippets` to
+include fragments from a common repository. Fragments are pure Markdown with
+no toolchain-specific syntax, ensuring they work in any repository's
+documentation build.
+
+Shared fragment inclusion:
 
 ```markdown
 --8<-- "shared-architecture-intro.md"
 ```
 
-Fragments are pure Markdown with no toolchain-specific syntax. This ensures
-they work in any repo's documentation build.
+The `pymdownx.snippets` base paths resolve in two contexts:
+
+- **CI**: Common repository checked out at a known path in the workspace.
+- **Local**: Common repository as a sibling directory.
+
+Repositories that do not share fragments omit the `base_path` configuration
+from `pymdownx.snippets`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,15 @@ repo_url: https://github.com/wphillipmoore/standards-and-conventions
 repo_name: wphillipmoore/standards-and-conventions
 
 docs_dir: docs
+strict: true
+edit_uri: ""
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

- Add mike versioning support to `mkdocs.yml` (`strict: true`, `extra.version.provider: mike`, `plugins: [search]`, `edit_uri: ""`)
- Convert `.github/workflows/docs.yml` from `mkdocs gh-deploy --force` to mike-based deployment with version determination for the docs-single-branch model
- Generalize `docs/development/documentation-toolchain.md` from mq-rest-admin family scope to canonical cross-repository standard, documenting both repository layout patterns and both branching model adaptations

Fixes #164

Docs-only: tests skipped

Files changed: `mkdocs.yml`, `.github/workflows/docs.yml`, `docs/development/documentation-toolchain.md`

## Test plan

- [x] Markdown linting passes (`scripts/lint/markdown-standards.sh`)
- [x] `mkdocs build --strict` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
