### PR TITLE
docs: make pr-workflow finalization mandatory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,34 +90,3 @@ shell escaping issues and preserves exact formatting.
 If you find yourself guessing at workflow rules, using trial-and-error, or
 backtracking due to errors, stop and read the relevant documentation before
 proceeding.
-
-## User Confirmation Checkpoints
-
-**Docs-only exception**: If the diff includes only documentation files (anything
-under `docs/` plus top-level `README.md` or `CHANGELOG.md`), skip both
-confirmation checkpoints and proceed directly through PR creation and
-finalization. Local validation is optional per the docs-only rule in
-`docs/code-management/pull-request-workflow.md`.
-
-**Finalize override**: If the user explicitly says "Finalize PR", treat that as
-approval to submit and finalize the PR for the current work without asking for
-"Submit PR?" or "Finalize PR?" again. This permission expires as soon as new
-work is performed (any new commit or file modification).
-
-### Checkpoint: Before Submitting Pull Request
-
-After completing work and committing to your feature branch:
-1. Run the repository's canonical validation command if it is documented.
-2. If no command is documented, ask the user for the required validation.
-3. Ask: "Submit PR?"
-
-Only proceed with PR submission after explicit user approval (or the Finalize
-override above).
-
-### Checkpoint: Before Finalizing Pull Request
-
-After submitting the PR, ask: "Finalize PR?" unless the Finalize override is
-active.
-
-"Finalize" means: merge the PR, delete the remote branch, update the local
-copy of the target branch, and run final validation (skip for docs-only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ The include directives above load the full repository standards. Key highlights 
 
 **Branching**: `develop` is the single eternal branch. All work happens on `feature/*` or `bugfix/*` branches merged back via PR.
 
-**Docs-only exception**: Since this is a documentation-only repository, the docs-only exception applies to all PRs. Local validation is optional per the docs-only rule, and confirmation checkpoints can be skipped.
+**Docs-only exception**: Since this is a documentation-only repository, the docs-only exception applies to all PRs. Local validation is optional per the docs-only rule.
 
 **Validation**: markdownlint is the canonical local validation tool. It must be on PATH (`markdownlint-cli`).
 

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -6,18 +6,23 @@ description: Guide pull request creation, submission, and finalization using the
 # PR workflow
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Preflight](#preflight)
 - [Docs-only determination](#docs-only-determination)
 - [Pre-submission steps](#pre-submission-steps)
-- [Submission and finalization](#submission-and-finalization)
+- [Submission](#submission)
+- [Finalization](#finalization)
 - [Resources](#resources)
 
 ## Overview
-Execute the pull request workflow with required validations and checkpoints.
-Follow local overrides (AGENTS or repo-specific standards) when present.
+
+Execute the full pull request lifecycle: validate, submit, merge, and clean up.
+This skill runs to completion without intermediate checkpoints. Auto-merge is
+always enabled; CI gates are the sole merge authority.
 
 ## Preflight
+
 - Confirm you are working on a short-lived branch per branching rules.
 - If no primary issue exists, create one immediately using best-effort
   assumptions and note them in the issue body. Do not ask for an issue number
@@ -27,6 +32,7 @@ Follow local overrides (AGENTS or repo-specific standards) when present.
   the commit standards and the repo's approved AI identity list.
 
 ## Docs-only determination
+
 - Identify whether the change set is "docs-only" as defined by the repository.
 - If the repository does not define a docs-only rule, ask for it before
   applying the exception.
@@ -34,6 +40,7 @@ Follow local overrides (AGENTS or repo-specific standards) when present.
   PR description and list the files changed.
 
 ## Pre-submission steps
+
 1. Run the repository's canonical validation command if documented.
 2. If no canonical command exists, ask for the required validation steps.
 3. If any check fails, do not submit the PR; fix and rerun the full checks.
@@ -43,22 +50,27 @@ Follow local overrides (AGENTS or repo-specific standards) when present.
    These are the only accepted keywords — `Closes`, `Resolves`, and other
    GitHub keywords are rejected by CI.
 
-## Submission and finalization
-- Submit the PR only after all required checks pass (unless docs-only
-  exception applies).
-- Follow repository-specific confirmation checkpoints if defined in AGENTS.
-- Auto-merge is the default unless the PR has a `manual-merge` label or the
-  repository disables auto-merge.
-- If auto-merge is enabled, do not attempt manual merge. Wait for required
-  checks to pass and for the merge to complete.
-- After merge approval or completion, finalize in order:
-  1. Merge the PR and delete the remote branch (or confirm auto-merge completed).
-  2. Update the local copy of the target branch.
-  3. Synchronize the local environment with dependency specifications.
-  4. Delete the local feature branch and prune stale remotes.
-  5. Run final validation (skip for docs-only PRs).
+## Submission
+
+1. Push the branch and create the PR.
+2. Enable auto-merge immediately. Do not attempt manual merge.
+3. Wait for CI to pass and auto-merge to complete.
+
+## Finalization
+
+After the PR merges, finalize in order:
+
+1. Update the local copy of the target branch.
+2. Delete the local feature branch.
+3. Prune stale remote-tracking references.
+4. Synchronize the local environment with dependency specifications.
+5. Run final validation (skip for docs-only PRs).
+
+Finalization is mandatory. Do not stop after submission or ask for permission
+to finalize.
 
 ## Resources
+
 - `docs/code-management/pull-request-workflow.md`
 - `docs/code-management/branching-and-deployment.md`
 - `docs/code-management/commit-messages-and-authorship.md`


### PR DESCRIPTION
## Summary

- Rewrite `pr-workflow` skill: split into separate Submission and Finalization phases
- Finalization is mandatory — no checkpoint, no permission prompt
- Auto-merge is always enabled; CI gates are the sole merge authority
- Remove obsolete "User Confirmation Checkpoints" section from AGENTS.md
- Remove stale checkpoint reference from CLAUDE.md docs-only exception

Docs-only: tests skipped

Files changed:
- `skills/pr-workflow/SKILL.md`
- `AGENTS.md`
- `CLAUDE.md`

Fixes #167
