### PR TITLE
fix: specify repository profile path in publish skill

### DIFF
--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -47,7 +47,8 @@ This skill is not applicable to application repositories.
 
 ## Preflight
 
-- Read the repository profile to determine `repository_type`.
+- Read `docs/repository-standards.md` and locate the repository profile section.
+- Read `repository_type` from the profile.
 - If the type is `library`, follow **library-release mode**.
 - If the type is `documentation`, follow **docs-only mode**.
 - If the type is anything else, stop and inform the user that this skill does


### PR DESCRIPTION
## Summary

- Specify exact file path (`docs/repository-standards.md`) in publish skill preflight instead of vague "read the repository profile"
- Prevents agents from searching for nonexistent profile files

Docs-only: tests skipped

Files changed:
- `skills/publish/SKILL.md`

Ref #148
