### PR TITLE
fix: add issue linkage to release PR bodies

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -192,6 +192,19 @@ def create_pr(version: str) -> str:
     )
     url = result.stdout.strip()
     print(f"PR created: {url}")
+
+    pr_number = url.rstrip("/").rsplit("/", 1)[-1]
+    body_with_linkage = (
+        f"## Summary\n\nRelease {version}\n\n"
+        f"Ref #{pr_number}\n\n"
+        f"Generated with `prepare_release.py`\n"
+    )
+    subprocess.run(  # noqa: S603
+        ("gh", "pr", "edit", url, "--body", body_with_linkage),
+        check=True,
+    )
+    print(f"PR body updated with issue linkage (Ref #{pr_number})")
+
     return url
 
 


### PR DESCRIPTION
## Summary

- After `gh pr create`, extract the PR number from the returned URL and
  update the PR body with a `Ref #N` line via `gh pr edit`
- Prevents the `pr-issue-linkage` check from failing on every release PR

Fixes #180

## Test plan

- [ ] Run prepare_release.py in a test repo and verify the PR body includes `Ref #N`
