### PR TITLE
fix: publish skill must return to clean develop after completion

### DIFF
--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -137,6 +137,9 @@ confirmed).
 5. Comment on the tracking issue with Phase 5 results (dependency update PR
    number, categories updated).
 6. Close the tracking issue with a final summary comment covering all phases.
+7. Return to a clean `develop` branch: update local `develop` to incorporate
+   the merged dependency update, delete the local feature branch, and prune
+   stale remotes. Run final validation to confirm a clean state.
 
 ## Docs-only mode
 
@@ -152,6 +155,9 @@ confirmed).
    [Dependency update categories](#dependency-update-categories)).
 3. Run full validation.
 4. Submit via `pr-workflow`.
+5. Return to a clean `develop` branch: update local `develop` to incorporate
+   the merged dependency update, delete the local feature branch, and prune
+   stale remotes. Run final validation to confirm a clean state.
 
 ## Dependency update categories
 


### PR DESCRIPTION
## Summary

- Add cleanup step to library-release Phase 5 and docs-only Phase 2 requiring the skill to return to a clean `develop` branch after completion
- Cleanup includes: update local develop, delete local feature branch, prune stale remotes, run final validation

Fixes #184

## Test plan

- [ ] Next publish run should end on `develop` with a clean working tree

Docs-only: tests skipped

Files changed: `skills/publish/SKILL.md`
