### PR TITLE
fix: merge main into release branch before generating changelog

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -151,6 +151,17 @@ def create_release_branch(branch: str) -> None:
     run_command(("git", "checkout", "-b", branch))
 
 
+def merge_main() -> None:
+    """Merge main into the release branch to incorporate prior release history.
+
+    This prevents CHANGELOG.md merge conflicts by ensuring the release branch
+    has main's version of the changelog before git-cliff regenerates it.
+    """
+    print("Merging main into release branch...")
+    run_command(("git", "fetch", "origin", "main"))
+    run_command(("git", "merge", "origin/main", "--no-edit"))
+
+
 def generate_changelog(version: str) -> bool:
     """Generate changelog via git-cliff if available. Return True if generated."""
     if not shutil.which("git-cliff"):
@@ -235,6 +246,7 @@ def main() -> int:
     print(f"Preparing release {version} ({ecosystem})")
 
     create_release_branch(branch)
+    merge_main()
     generate_changelog(version)
     push_branch(branch)
     url = create_pr(version, args.issue)


### PR DESCRIPTION
## Summary

- Add `merge_main()` step to `prepare_release.py` that merges main into the release branch before generating the changelog
- Prevents CHANGELOG.md merge conflicts caused by prior release merge commits on main diverging from develop's changelog

Fixes #186

## Test plan

- [ ] Next publish run should not hit a CHANGELOG.md merge conflict on the release PR

Docs-only: tests skipped

Files changed: `scripts/dev/prepare_release.py`
