### PR TITLE
fix: apply ruff formatting to prepare_release.py

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -162,11 +162,17 @@ def merge_main(version: str) -> None:
     """
     print("Merging main into release branch...")
     run_command(("git", "fetch", "origin", "main"))
-    run_command((
-        "git", "merge", "origin/main",
-        "-X", "ours",
-        "-m", f"chore: merge main into release/{version}",
-    ))
+    run_command(
+        (
+            "git",
+            "merge",
+            "origin/main",
+            "-X",
+            "ours",
+            "-m",
+            f"chore: merge main into release/{version}",
+        )
+    )
 
 
 def generate_changelog(version: str) -> bool:
@@ -197,18 +203,18 @@ def create_pr(version: str, issue: int) -> str:
     """Create a PR to main and return the PR URL."""
     print("Creating pull request to main...")
     title = f"release: {version}"
-    body = (
-        f"## Summary\n\n"
-        f"Release {version}\n\n"
-        f"Ref #{issue}\n\n"
-        f"Generated with `prepare_release.py`\n"
-    )
+    body = f"## Summary\n\nRelease {version}\n\nRef #{issue}\n\nGenerated with `prepare_release.py`\n"
     result = subprocess.run(  # noqa: S603
         (
-            "gh", "pr", "create",
-            "--base", "main",
-            "--title", title,
-            "--body", body,
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--title",
+            title,
+            "--body",
+            body,
         ),
         check=True,
         text=True,


### PR DESCRIPTION
## Summary

- Apply ruff formatting to `prepare_release.py` so it passes `ruff format --check` in the Python repo
- Three spots reformatted: `merge_main()` tuple args, `create_pr()` body f-string concatenation, and `create_pr()` subprocess tuple args

Fixes #194

## Test plan

- [ ] Next Python release cycle should pass `ruff format --check` on the synced script

Docs-only: tests skipped

Files changed: `scripts/dev/prepare_release.py`
