### PR TITLE
feat: add finalize_repo.sh and staleness check for prepare_release.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ The include directives above load the full repository standards. Key highlights 
   - `docs/research/` - Research reports
 - `skills/` - Shared agent skills loaded by downstream repositories
 - `scripts/` - Linting, git hook, and dev automation scripts
-  - `scripts/dev/` - Shared development scripts (prepare_release)
+  - `scripts/dev/` - Shared development scripts (prepare_release, finalize_repo)
 - `drafts/` - Work-in-progress content
 
 ## Skills

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -204,6 +204,9 @@ successfully and the PR is ready to merge (manually or via auto-merge). If a
 required check fails, resolve it immediately and re-run the checks before
 merging.
 
+When `scripts/dev/finalize_repo.sh` is available, run it after the merge
+completes to automate steps 3-5 below.
+
 Finalize the PR in this order:
 
 1. wait for all required checks to complete and pass

--- a/docs/code-management/workflow-runbooks.md
+++ b/docs/code-management/workflow-runbooks.md
@@ -77,7 +77,9 @@ Applies to all repositories governed by these standards.
 1. Wait for all required checks to complete and pass.
 2. If auto-merge is enabled, wait for the merge to complete before cleanup.
 3. Merge the pull request (if not already merged) and delete the remote branch.
-4. Update the local target branch.
+4. Run `scripts/dev/finalize_repo.sh` to update the local target branch, delete
+   merged branches, and prune remotes. If the script is not available, perform
+   steps 5-6 manually.
 5. Delete the local feature branch and prune remotes.
 6. Run final validation unless the docs-only exception applies.
 

--- a/scripts/dev/finalize_repo.sh
+++ b/scripts/dev/finalize_repo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Finalize a repository after a PR merge: switch to the target branch,
+# fast-forward pull, delete merged local branches, and prune remotes.
+
+# -- defaults ----------------------------------------------------------------
+
+target_branch="develop"
+dry_run=false
+
+# -- argument parsing --------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Finalize a repository after a PR merge.
+
+Options:
+  --target-branch BRANCH  Target branch to switch to (default: develop)
+  --dry-run               Show what would be done without making changes
+  -h, --help              Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-branch)
+      target_branch="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# -- eternal branch detection -----------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+branching_model=""
+
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+      branching_model="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+# Build the list of eternal branches to protect from deletion.
+eternal_branches=("gh-pages")
+
+case "$branching_model" in
+  docs-single-branch)
+    eternal_branches+=("develop")
+    ;;
+  library-release)
+    eternal_branches+=("develop" "main")
+    ;;
+  application-promotion)
+    eternal_branches+=("develop" "release" "main")
+    ;;
+  "")
+    echo "WARNING: branching_model not found; protecting develop and main." >&2
+    eternal_branches+=("develop" "main")
+    ;;
+  *)
+    echo "ERROR: unrecognized branching_model '$branching_model'." >&2
+    exit 1
+    ;;
+esac
+
+is_eternal() {
+  local branch="$1"
+  for eternal in "${eternal_branches[@]}"; do
+    if [[ "$branch" == "$eternal" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# -- helpers -----------------------------------------------------------------
+
+run() {
+  if [[ "$dry_run" == true ]]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# -- step 1: switch to target branch ----------------------------------------
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ "$current_branch" != "$target_branch" ]]; then
+  echo "Switching to $target_branch..."
+  run git checkout "$target_branch"
+else
+  echo "Already on $target_branch."
+fi
+
+# -- step 2: fetch and fast-forward pull ------------------------------------
+
+echo "Pulling latest from origin/$target_branch..."
+run git fetch origin "$target_branch"
+if [[ "$dry_run" != true ]]; then
+  git pull --ff-only origin "$target_branch"
+else
+  echo "  [dry-run] git pull --ff-only origin $target_branch"
+fi
+
+# -- step 3: delete merged local branches -----------------------------------
+
+echo "Checking for merged local branches..."
+deleted_branches=()
+
+for branch in $(git branch --merged "$target_branch" --format='%(refname:short)'); do
+  if is_eternal "$branch"; then
+    continue
+  fi
+  echo "  Deleting merged branch: $branch"
+  run git branch -d "$branch"
+  deleted_branches+=("$branch")
+done
+
+# -- step 4: prune stale remote-tracking references -------------------------
+
+echo "Pruning stale remote-tracking references..."
+run git remote prune origin
+
+# -- summary -----------------------------------------------------------------
+
+echo ""
+echo "Finalization complete."
+echo "  Branch: $target_branch"
+if [[ ${#deleted_branches[@]} -gt 0 ]]; then
+  echo "  Deleted: ${deleted_branches[*]}"
+else
+  echo "  Deleted: (none)"
+fi
+echo "  Remotes: pruned"

--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -126,6 +126,20 @@ def ensure_clean_tree() -> None:
         raise SystemExit(message)
 
 
+def ensure_develop_up_to_date() -> None:
+    """Fail if local develop is behind origin/develop."""
+    run_command(("git", "fetch", "origin", "develop"))
+    local_sha = read_command_output(("git", "rev-parse", "HEAD"))
+    remote_sha = read_command_output(("git", "rev-parse", "origin/develop"))
+    if local_sha != remote_sha:
+        message = (
+            f"Local develop ({local_sha[:8]}) does not match "
+            f"origin/develop ({remote_sha[:8]}). "
+            f"Pull latest changes before preparing a release."
+        )
+        raise SystemExit(message)
+
+
 def branch_exists(name: str) -> bool:
     """Return True if a branch exists locally or on origin."""
     for ref in (name, f"origin/{name}"):
@@ -258,6 +272,7 @@ def main() -> int:
 
     ensure_on_develop()
     ensure_clean_tree()
+    ensure_develop_up_to_date()
     ensure_tool_available("gh")
 
     ecosystem, version = detect_ecosystem()

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -58,13 +58,16 @@ always enabled; CI gates are the sole merge authority.
 
 ## Finalization
 
-After the PR merges, finalize in order:
+After the PR merges, run `scripts/dev/finalize_repo.sh` from the repository
+root. The script switches to the target branch, fast-forward pulls from origin,
+deletes merged local branches, and prunes stale remotes. If the script is not
+available, perform the steps manually:
 
-1. Update the local copy of the target branch.
+1. Switch to the target branch and pull latest from origin.
 2. Delete the local feature branch.
 3. Prune stale remote-tracking references.
-4. Synchronize the local environment with dependency specifications.
-5. Run final validation (skip for docs-only PRs).
+
+Then run final validation (skip for docs-only PRs).
 
 Finalization is mandatory. Do not stop after submission or ask for permission
 to finalize.

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -158,8 +158,8 @@ confirmed).
 6. Close the tracking issue with a final summary comment covering all phases.
    All issue and PR references in the summary must be full URLs (not short
    `#N` references) so they are clickable in the terminal.
-7. Return to a clean `develop` branch: update local `develop` to incorporate
-   the merged dependency update, delete the local feature branch, and prune
+7. Run `scripts/dev/finalize_repo.sh` to return to a clean `develop` branch.
+   The script updates local `develop`, deletes merged branches, and prunes
    stale remotes. Run final validation to confirm a clean state.
 
 ## Docs-only mode
@@ -176,8 +176,8 @@ confirmed).
    [Dependency update categories](#dependency-update-categories)).
 3. Run full validation.
 4. Submit via `pr-workflow`.
-5. Return to a clean `develop` branch: update local `develop` to incorporate
-   the merged dependency update, delete the local feature branch, and prune
+5. Run `scripts/dev/finalize_repo.sh` to return to a clean `develop` branch.
+   The script updates local `develop`, deletes merged branches, and prunes
    stale remotes. Run final validation to confirm a clean state.
 
 ## Dependency update categories


### PR DESCRIPTION
## Summary

- Add `scripts/dev/finalize_repo.sh` encapsulating post-merge git cleanup (switch to target branch, fast-forward pull, delete merged branches, prune remotes)
- Add `ensure_develop_up_to_date()` staleness safety net to `prepare_release.py`
- Update pr-workflow and publish skills to reference the script
- Update pull-request-workflow and workflow-runbooks standards docs to reference the script
- Update CLAUDE.md File Layout

Fixes #210

Docs-only: tests skipped

Files changed:
- `scripts/dev/finalize_repo.sh` (new)
- `scripts/dev/prepare_release.py`
- `skills/pr-workflow/SKILL.md`
- `skills/publish/SKILL.md`
- `docs/code-management/pull-request-workflow.md`
- `docs/code-management/workflow-runbooks.md`
- `CLAUDE.md`
