### PR TITLE
feat: require canonical validation script in all library repos

### DIFF
--- a/docs/development/python/local-validation-scripts.md
+++ b/docs/development/python/local-validation-scripts.md
@@ -1,57 +1,50 @@
-# Local validation scripts
+# Local Validation Scripts (Python)
 
 ## Table of Contents
 
 - [Purpose](#purpose)
 - [Scope](#scope)
-- [Requirements](#requirements)
+- [General standard](#general-standard)
+- [Python-specific requirements](#python-specific-requirements)
 - [CI parity](#ci-parity)
 - [Version validation](#version-validation)
-- [Failure behavior and output](#failure-behavior-and-output)
 
 ## Purpose
 
-Define the required behavior for repository-local validation scripts (for
-example, `scripts/dev/validate_local.py`) so local checks reliably match CI
-hard gates.
+Specialize the
+[ecosystem-agnostic local validation scripts standard](../../repository/local-validation-scripts.md)
+for Python repositories.
 
 ## Scope
 
 Applies to Python repositories that define a canonical local validation
-command. Repositories that do not define such a command must document their
-alternative process in the pull request workflow.
+command. All requirements from the
+[general standard](../../repository/local-validation-scripts.md) apply in
+addition to the Python-specific requirements below.
 
-## Requirements
+## General standard
+
+This document extends the
+[Local Validation Scripts](../../repository/local-validation-scripts.md)
+standard. Refer to that document for shared requirements including fail-fast
+behavior, prerequisite checks, non-zero exit codes, CI parity basics, and
+no-side-effects rules.
+
+## Python-specific requirements
 
 - Provide a canonical local validation command at `scripts/dev/validate_local.py`.
-- Run from the repository root and fail fast if executed elsewhere.
 - Invoke Python as `python3` and use the project environment.
-- Execute all CI hard-gate checks locally with the same tools and flags.
-- Permit additional local-only checks when documented, but never omit CI hard
-  gates.
-- Avoid side effects beyond validation (no automatic fixes or rewrites).
-- Return a non-zero exit code on failure.
 
 ## CI parity
 
-The local validation script must mirror CI hard gates, including:
+In addition to the general CI parity requirements, Python validation scripts
+must include:
 
-- dependency and lockfile validation
-- linting and type checking (run all required checkers, including mypy and ty)
-- tests with the same marker selection and coverage thresholds
-- security or dependency audits required by CI
-
-If CI separates unit and integration jobs, the local script must run both sets
-of tests to keep coverage and integration behavior aligned.
+- linting and type checking with all required checkers (including mypy and ty
+  when configured)
 
 ## Version validation
 
 If CI enforces version comparison against a base branch, the local script must
 support passing a base reference (for example, `--base-ref develop`) and must
 document the default behavior (for example, resolving `origin/HEAD`).
-
-## Failure behavior and output
-
-- Print the command being executed before each step.
-- Stop at the first failing command and return that exit code.
-- Surface missing prerequisites with actionable error messages.

--- a/docs/repository/local-validation-scripts.md
+++ b/docs/repository/local-validation-scripts.md
@@ -1,0 +1,92 @@
+# Local Validation Scripts
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Requirements](#requirements)
+- [CI parity](#ci-parity)
+- [Per-ecosystem examples](#per-ecosystem-examples)
+- [Ecosystem-specific standards](#ecosystem-specific-standards)
+
+## Purpose
+
+Define the required behavior for a canonical validation script that runs all
+CI hard-gate checks locally as a single command. This prevents agents and
+developers from cherry-picking individual validation commands and silently
+skipping checks when tools are missing.
+
+## Scope
+
+Applies to all repositories that define a `canonical_local_validation_command`
+in their repository profile. Repositories that do not define such a command
+must document their alternative process in the pull request workflow.
+
+## Requirements
+
+- Provide a canonical validation script (for example,
+  `scripts/dev/validate_local.py` or `scripts/validate.sh`). The path must
+  match the `canonical_local_validation_command` in the repository profile.
+- Check tool prerequisites before running any checks. Verify all required
+  tools are on PATH and exit with a clear, actionable error if any are missing.
+- Run from the repository root.
+- Execute all CI hard-gate checks locally with the same tools and flags.
+- Permit additional local-only checks when documented, but never omit CI hard
+  gates.
+- Print the command being executed before each step.
+- Stop at the first failing command and return that exit code (fail-fast).
+- Return a non-zero exit code on any failure.
+- Avoid side effects beyond validation (no automatic fixes or rewrites).
+
+## CI parity
+
+The local validation script must mirror CI hard gates, including:
+
+- dependency and lockfile validation
+- linting and formatting checks
+- type checking (when applicable)
+- tests with the same marker selection and coverage thresholds
+- security or dependency audits required by CI
+
+If CI separates unit and integration jobs, the local script must run both sets
+of tests to keep coverage and integration behavior aligned.
+
+## Per-ecosystem examples
+
+### Python
+
+```bash
+# Typical checks in a Python validation script
+ruff check .
+ruff format --check .
+mypy src/
+pytest tests/ --cov=src --cov-fail-under=90
+pip-audit
+```
+
+### Go
+
+```bash
+# Typical checks in a Go validation script
+go vet ./...
+staticcheck ./...
+go test -race -coverprofile=coverage.out ./...
+govulncheck ./...
+```
+
+### Java
+
+```bash
+# Typical checks in a Java validation script
+mvn checkstyle:check
+mvn spotbugs:check
+mvn test
+mvn dependency-check:check
+```
+
+## Ecosystem-specific standards
+
+Ecosystems may define specializations that extend this standard with
+language-specific requirements:
+
+- Python: [local-validation-scripts.md](../development/python/local-validation-scripts.md)

--- a/docs/repository/overview.md
+++ b/docs/repository/overview.md
@@ -19,3 +19,4 @@ do not define language-specific coding practices.
 ## Document Map
 
 - Repository structure: [repository-structure.md](repository-structure.md)
+- Local validation scripts: [local-validation-scripts.md](local-validation-scripts.md)

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -78,6 +78,7 @@ This list is the authoritative include chain for the shared standards corpus.
 
 <!-- include: docs/repository/overview.md -->
 <!-- include: docs/repository/repository-structure.md -->
+<!-- include: docs/repository/local-validation-scripts.md -->
 
 <!-- include: docs/dependencies/overview.md -->
 <!-- include: docs/dependencies/dependency-update-workflow.md -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
   - Repository:
       - Overview: repository/overview.md
       - Repository Structure: repository/repository-structure.md
+      - Local Validation Scripts: repository/local-validation-scripts.md
   - Dependencies:
       - Overview: dependencies/overview.md
       - Dependency Update Workflow: dependencies/dependency-update-workflow.md


### PR DESCRIPTION
## Summary

- Add ecosystem-agnostic local validation scripts standard at `docs/repository/local-validation-scripts.md` with prerequisite checks, fail-fast, CI parity, and per-ecosystem examples (Python, Go, Java)
- Refactor Python `local-validation-scripts.md` to reference the general standard as a parent, keeping only Python-specific requirements
- Add new doc to repository overview, standards include chain, and mkdocs nav

Closes #199

Docs-only: tests skipped

Files changed:
- `docs/repository/local-validation-scripts.md` (new)
- `docs/development/python/local-validation-scripts.md` (edited)
- `docs/repository/overview.md` (edited)
- `docs/standards-and-conventions.md` (edited)
- `mkdocs.yml` (edited)
