### PR TITLE
feat: add shared tooling sync and staleness documentation (#220)

### DIFF
--- a/docs/repository/overview.md
+++ b/docs/repository/overview.md
@@ -20,3 +20,4 @@ do not define language-specific coding practices.
 
 - Repository structure: [repository-structure.md](repository-structure.md)
 - Local validation scripts: [local-validation-scripts.md](local-validation-scripts.md)
+- Shared tooling sync: [shared-tooling-sync.md](shared-tooling-sync.md)

--- a/docs/repository/shared-tooling-sync.md
+++ b/docs/repository/shared-tooling-sync.md
@@ -1,0 +1,173 @@
+# Shared Tooling Sync
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Architecture](#architecture)
+- [Managed scripts](#managed-scripts)
+- [Sync mechanism](#sync-mechanism)
+- [Staleness gate](#staleness-gate)
+- [Handling staleness gate failures](#handling-staleness-gate-failures)
+- [Updating the canonical source](#updating-the-canonical-source)
+- [Adding a new managed script](#adding-a-new-managed-script)
+- [Bootstrapping a new repository](#bootstrapping-a-new-repository)
+
+## Purpose
+
+Shared scripts (lint, git hooks, dev tooling) are copied across all
+repositories. This design ensures tagged releases are fully self-contained
+for build reproducibility. The tradeoff is that copies can drift when a
+script is fixed in one repo but the fix is not propagated.
+
+The shared tooling sync mechanism solves this by establishing a single
+canonical source (`standard-tooling`) and a sync script that detects and
+fixes drift.
+
+## Architecture
+
+```text
+standard-tooling (canonical source)
+  └── scripts/
+       ├── lint/          ← canonical lint scripts
+       ├── git-hooks/     ← canonical git hooks
+       └── dev/           ← canonical dev scripts (incl. sync-tooling.sh)
+
+standard-actions
+  ├── scripts/            ← synced from standard-tooling
+  └── actions/standards-compliance/scripts/  ← also synced (--actions-compat)
+
+standards-and-conventions
+  └── scripts/            ← synced from standard-tooling
+
+mq-rest-admin-{go,java,python}
+  └── scripts/            ← synced from standard-tooling
+```
+
+Copies are the right model. Tagged releases must be self-contained so that
+any supported release line can be built without external dependencies. The
+sync mechanism keeps the develop branch up to date while preserving
+self-containment on release branches.
+
+## Managed scripts
+
+### Git hooks (local-only)
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/git-hooks/commit-msg` | Conventional Commits + co-author validation |
+| `scripts/git-hooks/pre-commit` | Branch naming enforcement |
+
+### Lint scripts (hooks + CI)
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/lint/co-author.sh` | Co-author trailer validation |
+| `scripts/lint/commit-message.sh` | Single commit message validation |
+| `scripts/lint/commit-messages.sh` | Commit range validation (CI) |
+| `scripts/lint/markdown-standards.sh` | Markdownlint + structural checks |
+| `scripts/lint/pr-issue-linkage.sh` | PR body issue linkage validation |
+| `scripts/lint/repo-profile.sh` | Repository profile validation |
+
+### Dev scripts
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/dev/sync-tooling.sh` | The sync mechanism itself |
+| `scripts/dev/prepare_release.py` | Automated release preparation |
+| `scripts/dev/finalize_repo.sh` | Post-merge cleanup |
+
+## Sync mechanism
+
+Each consuming repo has a copy of `scripts/dev/sync-tooling.sh`. The script
+compares local copies against the canonical versions in `standard-tooling`
+and can auto-fix drift.
+
+### Check mode (default)
+
+```bash
+scripts/dev/sync-tooling.sh --check
+```
+
+Compares each managed file against the canonical version. Exits non-zero if
+any file is stale or missing. Used by the CI staleness gate.
+
+### Fix mode
+
+```bash
+scripts/dev/sync-tooling.sh --fix
+```
+
+Overwrites local copies with canonical versions, preserving file
+permissions. If `sync-tooling.sh` itself is stale, it updates itself first
+and re-executes.
+
+### Pinning to a tag
+
+```bash
+scripts/dev/sync-tooling.sh --fix --ref v1.0.0
+```
+
+By default the script syncs against the latest tag in `standard-tooling`.
+Use `--ref` to pin to a specific version.
+
+### Actions compatibility
+
+```bash
+scripts/dev/sync-tooling.sh --fix --actions-compat
+```
+
+For `standard-actions` only. Additionally syncs lint scripts to
+`actions/standards-compliance/scripts/`.
+
+## Staleness gate
+
+The `standards-compliance` action in `standard-actions` includes a staleness
+gate step that runs on PRs targeting `develop`. The step:
+
+1. Checks if `scripts/dev/sync-tooling.sh` exists in the consuming repo
+2. If present, runs `sync-tooling.sh --check`
+3. If any managed files are stale, the gate fails
+
+The gate is opt-in: repositories without `sync-tooling.sh` skip silently.
+This enables incremental rollout.
+
+The gate only runs on develop-targeted PRs. Release branches and hotfix
+branches are not affected, preserving release stability.
+
+## Handling staleness gate failures
+
+When the staleness gate fails on a PR:
+
+1. Run `scripts/dev/sync-tooling.sh --fix` locally
+2. Review the changes (the updated files will appear in `git diff`)
+3. Commit the updated scripts
+4. Push to the PR branch
+
+The gate will pass on the next CI run.
+
+## Updating the canonical source
+
+To fix or improve a shared script:
+
+1. Make the change in `standard-tooling` on a feature branch
+2. PR to develop, merge
+3. Tag a new version (e.g., `v1.1.0`)
+4. In each consuming repo, run `scripts/dev/sync-tooling.sh --fix`
+5. The staleness gate will enforce the update on the next PR to develop
+
+Do not fix shared scripts directly in consuming repos. Changes made in
+consuming repos will be overwritten by the next sync.
+
+## Adding a new managed script
+
+1. Add the script to `standard-tooling`
+2. Add its path to the `MANAGED_FILES` array in `sync-tooling.sh`
+3. Tag a new version of `standard-tooling`
+4. Run `sync-tooling.sh --fix` in each consuming repo
+
+## Bootstrapping a new repository
+
+1. Copy `scripts/dev/sync-tooling.sh` from `standard-tooling`
+2. Run `scripts/dev/sync-tooling.sh --fix --ref v1.0.0`
+3. Commit the synced scripts
+4. The staleness gate is automatically active on the next PR to develop

--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sync-tooling.sh — keep local copies of shared scripts in sync with
+# the canonical versions in the standard-tooling repository.
+#
+# Usage:
+#   sync-tooling.sh [--check | --fix] [--ref TAG] [--actions-compat]
+#
+# --check           Compare local copies against standard-tooling (default)
+# --fix             Overwrite local copies with canonical versions
+# --ref TAG         Standard-tooling tag to sync to (default: latest tag)
+# --actions-compat  Also sync lint scripts to actions/standards-compliance/scripts/
+
+TOOLING_REPO="https://github.com/wphillipmoore/standard-tooling.git"
+
+# Managed files — paths relative to the repo root.
+MANAGED_FILES=(
+  scripts/git-hooks/commit-msg
+  scripts/git-hooks/pre-commit
+  scripts/lint/co-author.sh
+  scripts/lint/commit-message.sh
+  scripts/lint/commit-messages.sh
+  scripts/lint/markdown-standards.sh
+  scripts/lint/pr-issue-linkage.sh
+  scripts/lint/repo-profile.sh
+  scripts/dev/prepare_release.py
+  scripts/dev/finalize_repo.sh
+  scripts/dev/sync-tooling.sh
+)
+
+# Lint scripts that also get copied to the actions path.
+ACTIONS_LINT_FILES=(
+  scripts/lint/commit-messages.sh
+  scripts/lint/markdown-standards.sh
+  scripts/lint/pr-issue-linkage.sh
+  scripts/lint/repo-profile.sh
+)
+ACTIONS_SCRIPTS_DIR="actions/standards-compliance/scripts"
+
+# -- argument parsing --------------------------------------------------------
+
+mode="check"
+ref=""
+actions_compat=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Keep local copies of shared scripts in sync with standard-tooling.
+
+Options:
+  --check           Compare local copies (default)
+  --fix             Overwrite local copies with canonical versions
+  --ref TAG         Standard-tooling tag to sync to (default: latest tag)
+  --actions-compat  Also sync lint scripts to actions/standards-compliance/scripts/
+  -h, --help        Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      mode="check"
+      shift
+      ;;
+    --fix)
+      mode="fix"
+      shift
+      ;;
+    --ref)
+      ref="$2"
+      shift 2
+      ;;
+    --actions-compat)
+      actions_compat=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# -- resolve repo root -------------------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# -- clone canonical source ---------------------------------------------------
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if [[ -n "$ref" ]]; then
+  clone_ref="$ref"
+else
+  # Discover the latest tag without a full clone.
+  clone_ref="$(git ls-remote --tags --sort=-v:refname "$TOOLING_REPO" 'v*' \
+    | head -n 1 | sed 's|.*refs/tags/||')"
+  if [[ -z "$clone_ref" ]]; then
+    echo "ERROR: no tags found in $TOOLING_REPO" >&2
+    exit 1
+  fi
+fi
+
+echo "Syncing against standard-tooling @ $clone_ref"
+git clone --depth 1 --branch "$clone_ref" "$TOOLING_REPO" "$tmpdir/standard-tooling" 2>/dev/null
+
+canonical="$tmpdir/standard-tooling"
+
+# -- self-update check -------------------------------------------------------
+
+self_path="scripts/dev/sync-tooling.sh"
+self_local="$repo_root/$self_path"
+self_canonical="$canonical/$self_path"
+
+if [[ -f "$self_canonical" && -f "$self_local" ]]; then
+  if ! diff -q "$self_local" "$self_canonical" >/dev/null 2>&1; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "Updating sync-tooling.sh itself and re-executing..."
+      cp "$self_canonical" "$self_local"
+      chmod +x "$self_local"
+      # Re-exec with the same arguments.
+      exec "$self_local" --fix ${ref:+--ref "$ref"} ${actions_compat:+--actions-compat}
+    else
+      echo "STALE: $self_path"
+    fi
+  fi
+fi
+
+# -- compare / fix -----------------------------------------------------------
+
+stale=0
+
+for file in "${MANAGED_FILES[@]}"; do
+  local_file="$repo_root/$file"
+  canonical_file="$canonical/$file"
+
+  # Skip files that don't exist in canonical (repo-specific scripts).
+  if [[ ! -f "$canonical_file" ]]; then
+    continue
+  fi
+
+  if [[ ! -f "$local_file" ]]; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "ADDING: $file"
+      mkdir -p "$(dirname "$local_file")"
+      cp "$canonical_file" "$local_file"
+      chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+    else
+      echo "MISSING: $file"
+      stale=1
+    fi
+    continue
+  fi
+
+  if ! diff -q "$local_file" "$canonical_file" >/dev/null 2>&1; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "UPDATING: $file"
+      cp "$canonical_file" "$local_file"
+      chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+    else
+      echo "STALE: $file"
+      stale=1
+    fi
+  fi
+done
+
+# -- actions compat ----------------------------------------------------------
+
+if [[ "$actions_compat" == true ]]; then
+  for file in "${ACTIONS_LINT_FILES[@]}"; do
+    basename="$(basename "$file")"
+    local_file="$repo_root/$ACTIONS_SCRIPTS_DIR/$basename"
+    canonical_file="$canonical/$file"
+
+    if [[ ! -f "$canonical_file" ]]; then
+      continue
+    fi
+
+    if [[ ! -f "$local_file" ]]; then
+      if [[ "$mode" == "fix" ]]; then
+        echo "ADDING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        mkdir -p "$(dirname "$local_file")"
+        cp "$canonical_file" "$local_file"
+        chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+      else
+        echo "MISSING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        stale=1
+      fi
+      continue
+    fi
+
+    if ! diff -q "$local_file" "$canonical_file" >/dev/null 2>&1; then
+      if [[ "$mode" == "fix" ]]; then
+        echo "UPDATING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        cp "$canonical_file" "$local_file"
+        chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+      else
+        echo "STALE (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        stale=1
+      fi
+    fi
+  done
+fi
+
+# -- result ------------------------------------------------------------------
+
+if [[ "$mode" == "check" ]]; then
+  if [[ $stale -ne 0 ]]; then
+    echo ""
+    echo "Shared scripts are stale. Run 'scripts/dev/sync-tooling.sh --fix' to update."
+    exit 1
+  else
+    echo "All shared scripts are up to date."
+  fi
+else
+  echo "Sync complete."
+fi

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -6,15 +6,31 @@ head_ref="${2:-}"
 
 if [[ -z "$base_ref" || -z "$head_ref" ]]; then
   echo "ERROR: base and head refs are required." >&2
-  echo "Usage: scripts/lint/commit-messages.sh <base-ref> <head-ref>" >&2
+  echo "Usage: commit-messages.sh <base-ref> <head-ref>" >&2
   exit 2
+fi
+
+# Resolve bare branch names to origin/ when the local branch doesn't exist.
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
+  if git rev-parse --verify --quiet "origin/$base_ref" >/dev/null 2>&1; then
+    base_ref="origin/$base_ref"
+  fi
 fi
 
 conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
 
+# Commits at or before the cutoff SHA predate the conventional commits
+# convention and are excluded from validation.  Consuming repos pass their
+# own cutoff via the COMMIT_CUTOFF_SHA environment variable.
+CUTOFF_SHA="${COMMIT_CUTOFF_SHA:-}"
+
 failed=0
 
 while IFS= read -r commit_sha; do
+  # Skip commits that predate the conventional commits convention.
+  if [[ -n "$CUTOFF_SHA" ]] && git merge-base --is-ancestor "$commit_sha" "$CUTOFF_SHA" 2>/dev/null; then
+    continue
+  fi
   subject_line="$(git log -n 1 --format=%s "$commit_sha")"
   if [[ ! "$subject_line" =~ $conventional_regex ]]; then
     echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -1,27 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Collect standard docs (structural checks + markdownlint).
 files=()
 while IFS= read -r file; do
   files+=("$file")
-done < <(find docs -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+done < <(find docs -path docs/sphinx -prune -o -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
 
 if [[ -f README.md ]]; then
   files+=("README.md")
 fi
 
+# Collect doc-site files (markdownlint only — structural checks like
+# Table of Contents and single-H1 do not apply to pages built by
+# documentation site generators such as Sphinx, MkDocs, etc.).
+docsite_files=()
+for docsite_dir in docs/sphinx docs/site; do
+  if [[ -d "$docsite_dir" ]]; then
+    while IFS= read -r file; do
+      docsite_files+=("$file")
+    done < <(find "$docsite_dir" -type f -name "*.md")
+  fi
+done
+
+all_files=("${files[@]}" ${docsite_files[@]+"${docsite_files[@]}"})
+
+# CHANGELOG.md gets markdownlint only — no structural checks (no TOC,
+# multiple H2 headings are expected, heading hierarchy differs).
 if [[ -f CHANGELOG.md ]]; then
-  files+=("CHANGELOG.md")
+  all_files+=("CHANGELOG.md")
 fi
 
-if [[ ${#files[@]} -eq 0 ]]; then
+if [[ ${#all_files[@]} -eq 0 ]]; then
   echo "ERROR: no markdown files found to lint." >&2
   exit 2
-fi
-
-markdownlint_config=()
-if [[ -f ".markdownlint.yaml" ]]; then
-  markdownlint_config=(--config ".markdownlint.yaml")
 fi
 
 if command -v markdownlint >/dev/null 2>&1; then
@@ -32,16 +44,19 @@ else
 fi
 
 markdownlint_failed=0
-if ! "${markdownlint_cmd[@]}" ${markdownlint_config[@]+"${markdownlint_config[@]}"} "${files[@]}"; then
-  markdownlint_failed=1
+if [[ -f ".markdownlint.yaml" ]]; then
+  if ! "${markdownlint_cmd[@]}" --config ".markdownlint.yaml" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
+else
+  if ! "${markdownlint_cmd[@]}" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
 fi
 
 failed=0
 
 for file in "${files[@]}"; do
-  if [[ "$file" == "CHANGELOG.md" ]]; then
-    continue
-  fi
   awk -v file="$file" '
     BEGIN {
       in_code = 0

--- a/scripts/lint/pr-issue-linkage.sh
+++ b/scripts/lint/pr-issue-linkage.sh
@@ -18,8 +18,7 @@ if [[ -z "$pr_body" ]]; then
   exit 1
 fi
 
-if ! printf '%s
-' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+#[0-9]+'; then
+if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+#[0-9]+'; then
   echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123)." >&2
   exit 1
 fi

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Variables are read via indirect expansion (${!key}).
 set -euo pipefail
 
 profile_file="docs/repository-standards.md"


### PR DESCRIPTION
## Summary

- Add `sync-tooling.sh` from standard-tooling v1.0.0
- Sync all shared scripts to canonical reconciled versions
- Add `docs/repository/shared-tooling-sync.md` documenting the sync mechanism
- Update `docs/repository/overview.md` with new doc link
- Key reconciliation: origin/ fallback in commit-messages.sh, all GitHub closing keywords in pr-issue-linkage.sh, shellcheck pragma in repo-profile.sh, docsite exclusions in markdown-standards.sh

## Test plan

- [x] `scripts/lint/markdown-standards.sh` passes
- [ ] `scripts/dev/sync-tooling.sh --check` passes
- [ ] CI passes

Fixes #220

Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
