### PR TITLE
feat: publish docs with MkDocs Material + mike via docs-promotion model

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   workflow_dispatch:
 
 permissions:
@@ -30,13 +30,21 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          echo "version=dev" >> "$GITHUB_OUTPUT"
-          echo "alias=latest" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+            echo "alias=" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "alias=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Deploy with mike
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ALIAS: ${{ steps.version.outputs.alias }}
         run: |
-          mike deploy --push --update-aliases \
-            "$VERSION" "$ALIAS"
+          if [ -n "$ALIAS" ]; then
+            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
+          else
+            mike deploy --push "$VERSION"
+          fi
           mike set-default --push latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Both files share the same underlying standards via include directives, ensuring 
 <!-- include: docs/standards-and-conventions.md -->
 <!-- include: docs/repository-standards.md -->
 
+## Always-Loaded Skills
+
+These skills are loaded at session start so they're immediately available without explicit invocation. When a user provides skill attributes inline (e.g., "create a P0 enhancement for X"), skip the corresponding interactive questions and go straight to confirm-and-create.
+
+<!-- include: skills/new-issue/SKILL.md -->
+
 ## Project Overview
 
 This is the **canonical standards and conventions repository**. All other repositories reference it as their baseline for development standards, workflows, and AI agent guidance.
@@ -98,10 +104,10 @@ The include directives above load the full repository standards. Key highlights 
 **Repository Profile**:
 - repository_type: documentation
 - versioning_scheme: none
-- branching_model: docs-single-branch
+- branching_model: docs-promotion
 - release_model: none
 
-**Branching**: `develop` is the single eternal branch. All work happens on `feature/*` or `bugfix/*` branches merged back via PR.
+**Branching**: `develop` is the default branch (staging). `main` is the promotion target (live site). All work happens on `feature/*` or `bugfix/*` branches merged to `develop` via PR. Changes reach `main` via promotion PR from `develop`.
 
 **Docs-only exception**: Since this is a documentation-only repository, the docs-only exception applies to all PRs. Local validation is optional per the docs-only rule.
 

--- a/docs/code-management/documentation-branching-model.md
+++ b/docs/code-management/documentation-branching-model.md
@@ -8,23 +8,25 @@
 - [3. Core invariants](#3-core-invariants)
 - [4. Branch roles](#4-branch-roles)
   - [develop](#develop)
-- [5. Short-lived branches](#5-short-lived-branches)
+  - [main](#main)
+- [5. Promotion flow](#5-promotion-flow)
+- [6. Short-lived branches](#6-short-lived-branches)
   - [feature/*](#feature)
   - [bugfix/*](#bugfix)
-- [6. Validation expectations](#6-validation-expectations)
-- [7. Forbidden operations](#7-forbidden-operations)
-- [8. Related documents](#8-related-documents)
+- [7. Validation expectations](#7-validation-expectations)
+- [8. Forbidden operations](#8-forbidden-operations)
+- [9. Related documents](#9-related-documents)
 
 ## Status
 
-Active v0.2
+Active v0.3
 
 ---
 
 ## 1. Purpose
 
-Define a minimal branching model for documentation repositories that keeps the
-workflow simple and durable.
+Define the branching model for documentation repositories that supports a
+staging preview on `develop` and a live published site on `main`.
 
 ## 2. Scope
 
@@ -33,10 +35,11 @@ snippets only and do not publish deployable artifacts.
 
 ## 3. Core invariants
 
-- `develop` is the single eternal branch.
-- `main` is not used for documentation repositories.
-- All changes arrive via short-lived branches.
-- There are no release branches or promotion flows.
+- `develop` and `main` are the two eternal branches.
+- `develop` is the default branch and staging target.
+- `main` is the promotion target for live/published documentation.
+- All changes arrive via short-lived branches merged to `develop`.
+- Changes reach `main` only via promotion PR from `develop`.
 - Versioning is optional and not required for publication.
 
 ## 4. Branch roles
@@ -44,10 +47,25 @@ snippets only and do not publish deployable artifacts.
 ### develop
 
 - default branch for documentation
-- source of published GitHub content
-- integration and release branch when a single branch is used
+- integration branch for all changes
+- source of the staging/preview documentation site (`dev` version)
 
-## 5. Short-lived branches
+### main
+
+- promotion target for reviewed, publish-ready content
+- source of the live documentation site (`latest` version)
+- receives changes only from `develop` via PR
+
+## 5. Promotion flow
+
+To publish documentation changes to the live site:
+
+1. Merge feature/bugfix branches to `develop` via PR.
+2. Verify the staging site (`dev` version) renders correctly.
+3. Open a PR from `develop` to `main`.
+4. Merge the promotion PR to update the live site.
+
+## 6. Short-lived branches
 
 Use short-lived branches for all changes.
 
@@ -76,19 +94,21 @@ Rules:
 - merged into `develop`
 - deleted after merge
 
-## 6. Validation expectations
+## 7. Validation expectations
 
 Documentation repositories must run markdownlint for documentation validation.
 Automated test or release validation is not required. Additional validation is
 optional unless a specific repository documents a requirement.
 
-## 7. Forbidden operations
+## 8. Forbidden operations
 
-- direct commits to `develop`
-- long-lived branches other than `develop`
-- adding release branches or promotion flows without updating standards
+- direct commits to `develop` or `main`
+- long-lived branches other than `develop` and `main`
+- merging to `main` from any branch other than `develop`
+- force-pushing to `develop` or `main`
 
-## 8. Related documents
+## 9. Related documents
 
 - Repository types and attributes: [repository-types-and-attributes.md](repository-types-and-attributes.md)
 - Pull request workflow: [pull-request-workflow.md](pull-request-workflow.md)
+- Documentation toolchain: [../development/documentation-toolchain.md](../development/documentation-toolchain.md)

--- a/docs/code-management/repository-types-and-attributes.md
+++ b/docs/code-management/repository-types-and-attributes.md
@@ -77,7 +77,7 @@ Each repository must declare, at minimum:
 
 - `repository_type`: `application`, `library`, or `documentation`
 - `versioning_scheme`: `application`, `library`, `ecosystem-specific`, or `none`
-- `branching_model`: `application-promotion`, `library-release`, or `docs-single-branch`
+- `branching_model`: `application-promotion`, `library-release`, or `docs-promotion`
 - `release_model`: `environment-promotion`, `artifact-publishing`, or `none`
 - `supported_release_lines`: a single active line for applications; one or more
   `MAJOR.MINOR` lines for libraries; `none` for documentation

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -201,7 +201,7 @@ The `pre-commit` hook enforces two rules in order:
 
 | `branching_model` | Allowed prefixes |
 | --- | --- |
-| `docs-single-branch` | `feature/*`, `bugfix/*` |
+| `docs-promotion` | `feature/*`, `bugfix/*` |
 | `application-promotion` | `feature/*`, `bugfix/*`, `hotfix/*`, `promotion/*` |
 | `library-release` | `feature/*`, `bugfix/*`, `hotfix/*`, `release/*` |
 

--- a/docs/development/documentation-toolchain.md
+++ b/docs/development/documentation-toolchain.md
@@ -241,26 +241,36 @@ Key requirements:
 
 ### Version determination by branching model
 
-#### docs-single-branch
+#### docs-promotion
 
-Documentation-only repositories use `develop` as the single eternal branch.
-Since there is no `main` branch, `develop` represents the canonical state:
+Documentation-only repositories use `develop` for staging and `main` for
+the live site:
 
 ```yaml
 - name: Determine version
   id: version
   run: |
-    echo "version=dev" >> "$GITHUB_OUTPUT"
-    echo "alias=latest" >> "$GITHUB_OUTPUT"
+    if [ "${{ github.ref_name }}" = "main" ]; then
+      echo "version=latest" >> "$GITHUB_OUTPUT"
+      echo "alias=" >> "$GITHUB_OUTPUT"
+    else
+      echo "version=dev" >> "$GITHUB_OUTPUT"
+      echo "alias=" >> "$GITHUB_OUTPUT"
+    fi
 ```
 
-The workflow triggers only on `develop` pushes. The `dev` version always
-receives the `latest` alias since it is the only published version.
+- `main` branch: version `latest`, set as the default.
+- `develop` branch: version `dev`, no alias.
+
+Documentation repositories do not have a `VERSION` file, so `main` deploys
+directly as `latest` rather than a semver version aliased as `latest`.
+
+The workflow triggers on both `develop` and `main` pushes.
 
 #### application-promotion and library-release
 
 Repositories with both `develop` and `main` branches determine the version
-from the branch:
+from the branch and a `VERSION` file:
 
 ```yaml
 - name: Determine version

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -18,7 +18,7 @@
 
 - repository_type: documentation
 - versioning_scheme: none
-- branching_model: docs-single-branch
+- branching_model: docs-promotion
 - release_model: none
 - supported_release_lines: none
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -152,7 +152,7 @@ included from `AGENTS.md` only. Do not include it here.
 ## Repository profile
 - repository_type: <application|library|documentation>
 - versioning_scheme: <application|library|ecosystem-specific|none>
-- branching_model: <application-promotion|library-release|docs-single-branch>
+- branching_model: <application-promotion|library-release|docs-promotion>
 - release_model: <environment-promotion|artifact-publishing|none>
 - supported_release_lines: <single|list of MAJOR.MINOR lines|none>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,19 +34,13 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
-    - navigation.expand
-    - search.suggest
-    - search.highlight
+    - navigation.top
     - content.code.copy
+    - search.highlight
+    - search.suggest
 
 markdown_extensions:
   - admonition
-  - attr_list
-  - def_list
-  - md_in_html
-  - tables
-  - toc:
-      permalink: true
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
@@ -54,6 +48,9 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
 
 nav:
   - Home: index.md
@@ -61,14 +58,14 @@ nav:
       - Overview: foundation/overview.md
       - Markdown Standards: foundation/markdown-standards.md
       - Architecture Standards: foundation/architecture-standards.md
-      - Interaction Contract: foundation/interaction-contract.md
-      - Interaction Contract (Brief): foundation/interaction-contract-brief.md
       - AI-Assisted Development Loop: foundation/ai-assisted-development-loop.md
       - AI Code Review Guidelines: foundation/ai-code-review-guidelines.md
-      - Agent Boot Banner: foundation/agent-boot-banner.md
-      - Agent Guardrails: foundation/agent-guardrails.md
+      - Interaction Contract: foundation/interaction-contract.md
+      - Interaction Contract Brief: foundation/interaction-contract-brief.md
       - Agent Pre-Response Checklist: foundation/agent-pre-response-checklist.md
+      - Agent Guardrails: foundation/agent-guardrails.md
       - Agent Skills: foundation/agent-skills.md
+      - Agent Boot Banner: foundation/agent-boot-banner.md
       - Standards Bootstrap Protocol: foundation/standards-bootstrap-protocol.md
       - Cognitive Drift Log: foundation/cognitive-drift-log.md
       - Cognitive Regression Tests: foundation/cognitive-regression-tests.md
@@ -78,23 +75,25 @@ nav:
   - Code Management:
       - Overview: code-management/overview.md
       - Source Control Guidelines: code-management/source-control-guidelines.md
+      - Repository Types and Attributes: code-management/repository-types-and-attributes.md
       - Branching and Deployment: code-management/branching-and-deployment.md
-      - Documentation Branching Model: code-management/documentation-branching-model.md
       - Library Branching and Release: code-management/library-branching-and-release.md
-      - Commit Messages and Authorship: code-management/commit-messages-and-authorship.md
-      - Pull Request Workflow: code-management/pull-request-workflow.md
-      - GitHub Issues: code-management/github-issues.md
+      - Documentation Branching Model: code-management/documentation-branching-model.md
+      - Shared Actions Library: code-management/shared-actions-library.md
       - Hotfix Policy: code-management/hotfix-policy.md
+      - Release and Versioning: code-management/release-versioning.md
       - Application Versioning Scheme: code-management/application-versioning-scheme.md
       - Library Versioning Scheme: code-management/library-versioning-scheme.md
-      - Release and Versioning Policy: code-management/release-versioning.md
-      - Repository Types and Attributes: code-management/repository-types-and-attributes.md
-      - Shared Actions Library: code-management/shared-actions-library.md
+      - Pull Request Workflow: code-management/pull-request-workflow.md
       - Workflow Runbooks: code-management/workflow-runbooks.md
+      - Commit Messages and Authorship: code-management/commit-messages-and-authorship.md
+      - GitHub Issues: code-management/github-issues.md
+      - GitHub Projects: code-management/github-projects.md
   - Repository:
       - Overview: repository/overview.md
       - Repository Structure: repository/repository-structure.md
       - Local Validation Scripts: repository/local-validation-scripts.md
+      - Shared Tooling Sync: repository/shared-tooling-sync.md
   - Dependencies:
       - Overview: dependencies/overview.md
       - Dependency Update Workflow: dependencies/dependency-update-workflow.md
@@ -102,18 +101,18 @@ nav:
       - Overview: development/overview.md
       - Environment and Tooling: development/environment-and-tooling.md
       - Documentation Toolchain: development/documentation-toolchain.md
-      - Deprecation Warnings: development/deprecation-warnings.md
       - Runtime Version Support Policy: development/runtime-version-support-policy.md
+      - Deprecation Warnings: development/deprecation-warnings.md
       - Python:
           - Overview: development/python/overview.md
-          - Naming Conventions: development/python/naming-conventions.md
-          - Type Hints: development/python/type-hints.md
           - Dependency Management: development/python/dependency-management.md
-          - Testing and Coverage: development/python/testing-and-coverage.md
           - Import-Time Side Effects: development/python/import-time-side-effects.md
-          - Local Validation Scripts: development/python/local-validation-scripts.md
+          - Testing and Coverage: development/python/testing-and-coverage.md
+          - Type Hints: development/python/type-hints.md
+          - Naming Conventions: development/python/naming-conventions.md
           - Version Management: development/python/version-management.md
-          - Ty Migration Plan: development/python/ty-migration-plan.md
+          - ty Migration Plan: development/python/ty-migration-plan.md
+          - Local Validation Scripts: development/python/local-validation-scripts.md
       - Go:
           - Overview: development/go/overview.md
           - Naming Conventions: development/go/naming-conventions.md

--- a/scripts/dev/finalize_repo.sh
+++ b/scripts/dev/finalize_repo.sh
@@ -65,8 +65,8 @@ fi
 eternal_branches=("gh-pages")
 
 case "$branching_model" in
-  docs-single-branch)
-    eternal_branches+=("develop")
+  docs-promotion)
+    eternal_branches+=("develop" "main")
     ;;
   library-release)
     eternal_branches+=("develop" "main")

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -35,7 +35,7 @@ fi
 
 # Set allowed branch prefixes based on branching model.
 case "$branching_model" in
-  docs-single-branch)
+  docs-promotion)
     allowed_regex='^(feature|bugfix)/'
     allowed_display="feature/* or bugfix/*"
     ;;


### PR DESCRIPTION
## Summary

- Replace `docs-single-branch` with `docs-promotion` branching model across all standards, scripts, and hooks
- Update mkdocs.yml with complete nav tree and docs.yml workflow to deploy from both `develop` (dev) and `main` (latest) branches
- Always-load new-issue skill in CLAUDE.md for shorthand invocation

Resolves #161

Docs-only: tests skipped

### Files changed

- `.github/workflows/docs.yml` — trigger on develop+main, conditional mike deploy
- `docs/code-management/documentation-branching-model.md` — v0.2→v0.3, add main branch role and promotion flow
- `docs/code-management/repository-types-and-attributes.md` — enum update
- `docs/code-management/source-control-guidelines.md` — branch prefix table update
- `docs/development/documentation-toolchain.md` — docs-promotion version determination section
- `docs/repository-standards.md` — repo profile update
- `docs/standards-and-conventions.md` — template enum update
- `mkdocs.yml` — complete nav, aligned with toolchain standard
- `scripts/dev/finalize_repo.sh` — docs-promotion case with develop+main
- `scripts/git-hooks/pre-commit` — docs-promotion case
- `CLAUDE.md` — always-load new-issue skill, branching model update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
