### PR TITLE
fix: always use --update-aliases in mike deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,6 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           ALIAS: ${{ steps.version.outputs.alias }}
         run: |
-          if [ -n "$ALIAS" ]; then
-            mike deploy --push --update-aliases "$VERSION" "$ALIAS"
-          else
-            mike deploy --push "$VERSION"
-          fi
+          mike deploy --push --update-aliases \
+            "$VERSION" $ALIAS
           mike set-default --push latest


### PR DESCRIPTION
## Summary

- Always pass `--update-aliases` to `mike deploy` to avoid "version already exists" error on repeated deployments
- Simplifies the deploy step to match the standard workflow template in the toolchain docs

Ref #161

Docs-only: tests skipped

### Files changed

- `.github/workflows/docs.yml` — remove conditional alias handling, always use `--update-aliases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
