### PR TITLE
feat: drop TOC requirement for MkDocs doc trees

### DIFF
--- a/docs/code-management/application-versioning-scheme.md
+++ b/docs/code-management/application-versioning-scheme.md
@@ -1,19 +1,5 @@
 # Application Versioning Scheme
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Operating model](#operating-model)
-- [Invariants](#invariants)
-- [Version format](#version-format)
-- [Source of truth](#source-of-truth)
-- [Increment rules](#increment-rules)
-- [Build derivation](#build-derivation)
-- [Promotion workflow](#promotion-workflow)
-- [Validation and failure modes](#validation-and-failure-modes)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Ensure every deployed application artifact has a unique, human-readable version

--- a/docs/code-management/branching-and-deployment.md
+++ b/docs/code-management/branching-and-deployment.md
@@ -1,24 +1,5 @@
 # Branching and Deployment Model
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Scope](#2-scope)
-- [3. Core Invariants](#3-core-invariants)
-- [4. Deployment Environments](#4-deployment-environments)
-- [5. Eternal Branches](#5-eternal-branches)
-  - [Pull Request Requirement](#pull-request-requirement)
-- [6. Short-Lived Branches](#6-short-lived-branches)
-  - [Branch Naming Conventions](#branch-naming-conventions)
-  - [feature/*](#feature)
-  - [bugfix/*](#bugfix)
-  - [hotfix/*](#hotfix)
-  - [promotion/*](#promotion)
-- [7. Promotion Flow](#7-promotion-flow)
-- [8. Forbidden Operations](#8-forbidden-operations)
-- [9. Guiding Principle](#9-guiding-principle)
-
 ## Status
 
 Active v0.2

--- a/docs/code-management/commit-messages-and-authorship.md
+++ b/docs/code-management/commit-messages-and-authorship.md
@@ -1,19 +1,5 @@
 # Commit Messages and Authorship
 
-## Table of Contents
-
-- [Commit Message Format](#commit-message-format)
-- [Types](#types)
-- [Example](#example)
-- [Commit Authorship](#commit-authorship)
-- [AI Co-Authorship](#ai-co-authorship)
-- [AI identity strategy](#ai-identity-strategy)
-- [Adding a New AI Service Account](#adding-a-new-ai-service-account)
-  - [Step-by-step checklist](#step-by-step-checklist)
-  - [Practical example: wphillipmoore-codex](#practical-example-wphillipmoore-codex)
-- [Scaling to shared ownership](#scaling-to-shared-ownership)
-- [Project-specific AI identities](#project-specific-ai-identities)
-
 ## Commit Message Format
 
 Follow Conventional Commits:

--- a/docs/code-management/documentation-branching-model.md
+++ b/docs/code-management/documentation-branching-model.md
@@ -1,22 +1,5 @@
 # Documentation Branching Model
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Scope](#2-scope)
-- [3. Core invariants](#3-core-invariants)
-- [4. Branch roles](#4-branch-roles)
-  - [develop](#develop)
-  - [main](#main)
-- [5. Promotion flow](#5-promotion-flow)
-- [6. Short-lived branches](#6-short-lived-branches)
-  - [feature/*](#feature)
-  - [bugfix/*](#bugfix)
-- [7. Validation expectations](#7-validation-expectations)
-- [8. Forbidden operations](#8-forbidden-operations)
-- [9. Related documents](#9-related-documents)
-
 ## Status
 
 Active v0.3

--- a/docs/code-management/github-issues.md
+++ b/docs/code-management/github-issues.md
@@ -1,18 +1,5 @@
 # GitHub Issue Standards
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Core rules](#core-rules)
-- [Acceptance criteria](#acceptance-criteria)
-- [Issue templates](#issue-templates)
-- [Issue creation and linking](#issue-creation-and-linking)
-- [Sub-issues](#sub-issues)
-- [Closing behavior](#closing-behavior)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define a consistent, enforced workflow for GitHub issues so all changes are

--- a/docs/code-management/github-projects.md
+++ b/docs/code-management/github-projects.md
@@ -1,19 +1,5 @@
 # GitHub Projects
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Project structure](#project-structure)
-- [Custom fields](#custom-fields)
-- [Views](#views)
-- [Workflows and automations](#workflows-and-automations)
-- [Integration with development workflow](#integration-with-development-workflow)
-- [User guide](#user-guide)
-- [Known limitations](#known-limitations)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define how GitHub Projects is used to plan, prioritize, and track work across

--- a/docs/code-management/hotfix-policy.md
+++ b/docs/code-management/hotfix-policy.md
@@ -1,17 +1,5 @@
 # Hotfix Policy
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Definition](#2-definition)
-- [3. Branching Rules](#3-branching-rules)
-- [4. Merge Requirements](#4-merge-requirements)
-- [5. Cultural Invariant](#5-cultural-invariant)
-- [6. Postmortem Requirement](#6-postmortem-requirement)
-- [7. Forbidden Practices](#7-forbidden-practices)
-- [8. Guiding Principle](#8-guiding-principle)
-
 ## Status
 
 Frozen v0.1 snapshot

--- a/docs/code-management/library-branching-and-release.md
+++ b/docs/code-management/library-branching-and-release.md
@@ -1,27 +1,5 @@
 # Library Branching and Release Model
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Scope](#2-scope)
-- [3. Core invariants](#3-core-invariants)
-- [4. Branch roles](#4-branch-roles)
-  - [main](#main)
-  - [develop](#develop)
-  - [release branches](#release-branches)
-- [5. Short-lived branches](#5-short-lived-branches)
-  - [feature/*](#feature)
-  - [bugfix/*](#bugfix)
-  - [hotfix/*](#hotfix)
-  - [chore/*](#chore)
-- [6. Release workflow](#6-release-workflow)
-- [7. Post-publish automation](#7-post-publish-automation)
-- [8. Pre-release policy](#8-pre-release-policy)
-- [9. Backporting policy](#9-backporting-policy)
-- [10. Forbidden operations](#10-forbidden-operations)
-- [11. Related documents](#11-related-documents)
-
 ## Status
 
 Active v0.3

--- a/docs/code-management/library-versioning-scheme.md
+++ b/docs/code-management/library-versioning-scheme.md
@@ -1,18 +1,5 @@
 # Library Versioning Scheme
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Invariants](#invariants)
-- [Version format](#version-format)
-- [Source of truth](#source-of-truth)
-- [Increment rules](#increment-rules)
-- [Release workflow](#release-workflow)
-- [Dependency management](#dependency-management)
-- [Validation and failure modes](#validation-and-failure-modes)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define how supporting libraries are versioned, released, and consumed.

--- a/docs/code-management/overview.md
+++ b/docs/code-management/overview.md
@@ -1,11 +1,5 @@
 # Code Management Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define reusable standards for source control, branching, releases, and pull

--- a/docs/code-management/pull-request-workflow.md
+++ b/docs/code-management/pull-request-workflow.md
@@ -1,19 +1,5 @@
 # Pull Request Workflow
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Docs-Only Exception](#docs-only-exception)
-- [Issue linkage](#issue-linkage)
-- [Pull request template](#pull-request-template)
-- [Pre-Submission Requirements](#pre-submission-requirements)
-- [Pre-Submission Checklist](#pre-submission-checklist)
-- [Pull request submission](#pull-request-submission)
-- [What to Do When Checks Fail](#what-to-do-when-checks-fail)
-- [Auto-merge policy](#auto-merge-policy)
-- [Async finalization guardrail](#async-finalization-guardrail)
-- [Pull Request Finalization](#pull-request-finalization)
-
 ## Purpose
 
 Pull requests must pass all hard-gate automated checks before submission. CI

--- a/docs/code-management/release-versioning.md
+++ b/docs/code-management/release-versioning.md
@@ -1,21 +1,5 @@
 # Release and Versioning Policy
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Release Definition](#2-release-definition)
-  - [Application repositories](#application-repositories)
-  - [Library repositories](#library-repositories)
-  - [Documentation repositories](#documentation-repositories)
-- [3. Versioning](#3-versioning)
-- [4. Pre-release policy](#4-pre-release-policy)
-- [5. Artifact Properties](#5-artifact-properties)
-- [6. Relationship to Branches](#6-relationship-to-branches)
-- [7. Rollback Strategy](#7-rollback-strategy)
-- [8. Forbidden Practices](#8-forbidden-practices)
-- [9. Guiding Principle](#9-guiding-principle)
-
 ## Status
 
 Active v0.2

--- a/docs/code-management/repository-types-and-attributes.md
+++ b/docs/code-management/repository-types-and-attributes.md
@@ -1,19 +1,5 @@
 # Repository Types and Attributes
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Core concepts](#core-concepts)
-- [Repository types](#repository-types)
-  - [Application repositories](#application-repositories)
-  - [Library repositories](#library-repositories)
-  - [Documentation repositories](#documentation-repositories)
-- [Required repository attributes](#required-repository-attributes)
-- [Declaration requirement](#declaration-requirement)
-- [Change control](#change-control)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define the repository classifications and metadata needed to select the correct

--- a/docs/code-management/shared-actions-library.md
+++ b/docs/code-management/shared-actions-library.md
@@ -1,18 +1,5 @@
 # Shared Actions Library
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Design principles](#design-principles)
-- [Repository structure](#repository-structure)
-- [Action design rules](#action-design-rules)
-- [Versioning and pinning](#versioning-and-pinning)
-- [Security and permissions](#security-and-permissions)
-- [Adoption workflow](#adoption-workflow)
-- [Implementation plan](#implementation-plan)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define standards for a shared GitHub Actions library that provides reusable,

--- a/docs/code-management/source-control-guidelines.md
+++ b/docs/code-management/source-control-guidelines.md
@@ -1,29 +1,5 @@
 # Source Code Management Guidelines
 
-## Table of Contents
-
-- [Status](#status)
-- [1. AI Assistance (Explicitly Bounded)](#1-ai-assistance-explicitly-bounded)
-- [2. Version Control Platform](#2-version-control-platform)
-  - [Lock-In Awareness](#lock-in-awareness)
-- [3. Repository Strategy](#3-repository-strategy)
-  - [Core Philosophy](#core-philosophy)
-  - [Boundary Rule](#boundary-rule)
-  - [Explicit Non-Decision](#explicit-non-decision)
-- [4. Runtime Version Policy](#4-runtime-version-policy)
-  - [Deployment Rule](#deployment-rule)
-- [5. CI/CD Constraints](#5-cicd-constraints)
-  - [CI gates](#ci-gates)
-  - [Docs-only CI skip policy](#docs-only-ci-skip-policy)
-  - [Local enforcement hooks](#local-enforcement-hooks)
-- [6. GitHub Repository Settings](#6-github-repository-settings)
-  - [Automatically delete head branches](#automatically-delete-head-branches)
-  - [GitHub repository rulesets](#github-repository-rulesets)
-- [7. Locked vs. Flexible Decisions](#7-locked-vs-flexible-decisions)
-  - [Locked at v0.1](#locked-at-v01)
-  - [Explicitly Flexible](#explicitly-flexible)
-- [8. Guiding Principle](#8-guiding-principle)
-
 ## Status
 
 Active v0.2

--- a/docs/code-management/workflow-runbooks.md
+++ b/docs/code-management/workflow-runbooks.md
@@ -1,19 +1,5 @@
 # Workflow runbooks
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Session startup runbook](#session-startup-runbook)
-- [Issue creation runbook](#issue-creation-runbook)
-- [Branching runbook](#branching-runbook)
-- [Change execution runbook](#change-execution-runbook)
-- [Validation runbook](#validation-runbook)
-- [Pull request submission runbook](#pull-request-submission-runbook)
-- [Pull request finalization runbook](#pull-request-finalization-runbook)
-- [Docs-only exception runbook](#docs-only-exception-runbook)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Provide deterministic, step-by-step workflows that remove ambiguity in common

--- a/docs/dependencies/dependency-update-workflow.md
+++ b/docs/dependencies/dependency-update-workflow.md
@@ -1,15 +1,5 @@
 # Dependency update workflow
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Sources of truth](#sources-of-truth)
-- [Workflow](#workflow)
-- [Failure handling](#failure-handling)
-- [Release-cycle review](#release-cycle-review)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define a repeatable, cross-ecosystem workflow for dependency updates that

--- a/docs/dependencies/overview.md
+++ b/docs/dependencies/overview.md
@@ -1,14 +1,5 @@
 # Dependency Anchor Records
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Required layout](#required-layout)
-- [Record format](#record-format)
-- [Maintenance](#maintenance)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Provide a durable record of why a dependency is anchored below the latest

--- a/docs/development/database/conventions.md
+++ b/docs/development/database/conventions.md
@@ -1,16 +1,5 @@
 # Database Conventions
 
-## Table of Contents
-
-- [Schema design](#schema-design)
-- [Table Naming](#table-naming)
-- [Model File Organization](#model-file-organization)
-  - [Rule 1: One File Per Table](#rule-1-one-file-per-table)
-  - [Rule 2: Tightly Coupled One-to-One Tables](#rule-2-tightly-coupled-one-to-one-tables)
-  - [Rule 3: Association Tables](#rule-3-association-tables)
-  - [Rule 4: Gray Areas](#rule-4-gray-areas)
-  - [Revisiting the Rules](#revisiting-the-rules)
-
 ## Schema design
 
 - Prefer fully normalized schemas with first-class tables and typed columns.

--- a/docs/development/database/overview.md
+++ b/docs/development/database/overview.md
@@ -1,11 +1,5 @@
 # Database Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define reusable database conventions that keep schemas and models consistent

--- a/docs/development/deprecation-warnings.md
+++ b/docs/development/deprecation-warnings.md
@@ -1,16 +1,5 @@
 # Deprecation Warning Policy
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Triage workflow](#triage-workflow)
-- [Dependency upgrade handling](#dependency-upgrade-handling)
-- [Warning suppression policy](#warning-suppression-policy)
-- [Issue template](#issue-template)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define a consistent policy for triaging and resolving deprecation warnings so

--- a/docs/development/documentation-toolchain.md
+++ b/docs/development/documentation-toolchain.md
@@ -1,16 +1,5 @@
 # Documentation Toolchain
 
-## Table of Contents
-
-- [Decision](#decision)
-- [Status](#status)
-- [Context](#context)
-- [Comparison](#comparison)
-- [Rationale](#rationale)
-- [Required Configuration](#required-configuration)
-- [CI Workflow Pattern](#ci-workflow-pattern)
-- [Shared Fragment Architecture](#shared-fragment-architecture)
-
 ## Decision
 
 All repositories use **MkDocs Material** with **mike** versioning as the

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -1,13 +1,5 @@
 # Development Environment and Tooling
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Virtual Environment Requirement](#virtual-environment-requirement)
-- [Python invocation and venv activation](#python-invocation-and-venv-activation)
-- [External Tooling Dependencies](#external-tooling-dependencies)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Define baseline expectations for development environments and external tooling.

--- a/docs/development/go/naming-conventions.md
+++ b/docs/development/go/naming-conventions.md
@@ -1,19 +1,5 @@
 # Go Naming Conventions
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Effective Go Baseline](#effective-go-baseline)
-- [Casing Convention Note](#casing-convention-note)
-- [Variable Naming Rules](#variable-naming-rules)
-  - [1. Struct-to-Variable Mapping](#1-struct-to-variable-mapping)
-  - [2. Minimum Length: 3+ Characters](#2-minimum-length-3-characters)
-  - [3. Complete English Words](#3-complete-english-words)
-  - [4. Namespace Collision Handling](#4-namespace-collision-handling)
-  - [5. Boolean Variables](#5-boolean-variables)
-  - [6. Collections: Plural vs. Singular](#6-collections-plural-vs-singular)
-  - [7. Consistency Rules](#7-consistency-rules)
-
 ## Purpose
 
 Provide naming rules that optimize for clarity, consistency, and accessibility.

--- a/docs/development/go/overview.md
+++ b/docs/development/go/overview.md
@@ -1,13 +1,5 @@
 # Go Development Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Principles](#core-principles)
-- [Tooling Expectations](#tooling-expectations)
-- [CI Gates](#ci-gates)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define consistent Go standards that emphasize readability, maintainability,

--- a/docs/development/java/naming-conventions.md
+++ b/docs/development/java/naming-conventions.md
@@ -1,19 +1,5 @@
 # Java Naming Conventions
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Google Java Style Guide Baseline](#google-java-style-guide-baseline)
-- [Casing Convention Note](#casing-convention-note)
-- [Variable Naming Rules](#variable-naming-rules)
-  - [1. Class-to-Variable Mapping](#1-class-to-variable-mapping)
-  - [2. Minimum Length: 3+ Characters](#2-minimum-length-3-characters)
-  - [3. Complete English Words](#3-complete-english-words)
-  - [4. Namespace Collision Handling](#4-namespace-collision-handling)
-  - [5. Boolean Variables](#5-boolean-variables)
-  - [6. Collections: Plural vs. Singular](#6-collections-plural-vs-singular)
-  - [7. Consistency Rules](#7-consistency-rules)
-
 ## Purpose
 
 Provide naming rules that optimize for clarity, consistency, and accessibility.

--- a/docs/development/java/overview.md
+++ b/docs/development/java/overview.md
@@ -1,13 +1,5 @@
 # Java Coding Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Principles](#core-principles)
-- [Tooling Expectations](#tooling-expectations)
-- [CI Gates](#ci-gates)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define consistent Java standards that emphasize readability, maintainability,

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,11 +1,5 @@
 # Development Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define reusable development standards that apply across languages and tooling.

--- a/docs/development/python/dependency-management.md
+++ b/docs/development/python/dependency-management.md
@@ -1,24 +1,5 @@
 # Python Dependency Management
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Sources of truth](#sources-of-truth)
-- [Version specification rules](#version-specification-rules)
-- [Upgrade workflow](#upgrade-workflow)
-  - [Patch-level](#patch-level)
-  - [Minor- or major-level](#minor--or-major-level)
-- [In-cycle exception rules](#in-cycle-exception-rules)
-- [Handling regressions and non-latest pins](#handling-regressions-and-non-latest-pins)
-- [Anchored dependency documentation](#anchored-dependency-documentation)
-- [Pre-release dependencies](#pre-release-dependencies)
-- [Security-driven updates](#security-driven-updates)
-- [Locked dependency review](#locked-dependency-review)
-- [Enforcement](#enforcement)
-- [Examples (TODO)](#examples-todo)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define strict, repeatable rules for Python dependency management to reduce

--- a/docs/development/python/import-time-side-effects.md
+++ b/docs/development/python/import-time-side-effects.md
@@ -1,11 +1,5 @@
 # Python Import-Time Side Effects
 
-## Table of Contents
-
-- [Rule](#rule)
-- [Allowed Exceptions](#allowed-exceptions)
-- [Forbidden Examples](#forbidden-examples)
-
 ## Rule
 
 No implicit state or side effects at import time.

--- a/docs/development/python/local-validation-scripts.md
+++ b/docs/development/python/local-validation-scripts.md
@@ -1,14 +1,5 @@
 # Local Validation Scripts (Python)
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [General standard](#general-standard)
-- [Python-specific requirements](#python-specific-requirements)
-- [CI parity](#ci-parity)
-- [Version validation](#version-validation)
-
 ## Purpose
 
 Specialize the

--- a/docs/development/python/naming-conventions.md
+++ b/docs/development/python/naming-conventions.md
@@ -1,18 +1,5 @@
 # Python Naming Conventions
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [PEP 8 Baseline](#pep-8-baseline)
-- [Variable Naming Rules](#variable-naming-rules)
-  - [1. Class-to-Variable Mapping](#1-class-to-variable-mapping)
-  - [2. Minimum Length: 3+ Characters](#2-minimum-length-3-characters)
-  - [3. Complete English Words](#3-complete-english-words)
-  - [4. Namespace Collision Handling](#4-namespace-collision-handling)
-  - [5. Boolean Variables](#5-boolean-variables)
-  - [6. Collections: Plural vs. Singular](#6-collections-plural-vs-singular)
-  - [7. Consistency Rules](#7-consistency-rules)
-
 ## Purpose
 
 Provide naming rules that optimize for clarity, consistency, and accessibility.

--- a/docs/development/python/overview.md
+++ b/docs/development/python/overview.md
@@ -1,13 +1,5 @@
 # Python Coding Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Principles](#core-principles)
-- [Tooling Expectations](#tooling-expectations)
-- [CI Gates](#ci-gates)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define consistent Python standards that emphasize readability, maintainability,

--- a/docs/development/python/testing-and-coverage.md
+++ b/docs/development/python/testing-and-coverage.md
@@ -1,16 +1,5 @@
 # Python Testing and Coverage
 
-## Table of Contents
-
-- [Core Principle](#core-principle)
-- [Default Assumption](#default-assumption)
-- [Exceptions](#exceptions)
-- [Coverage Target](#coverage-target)
-- [Untestable Code Documentation](#untestable-code-documentation)
-- [Coverage Reporting](#coverage-reporting)
-- [Coverage Expectations](#coverage-expectations)
-- [Rationale](#rationale)
-
 ## Core Principle
 
 Maintain code coverage as close to 100 percent as reasonably possible.

--- a/docs/development/python/ty-migration-plan.md
+++ b/docs/development/python/ty-migration-plan.md
@@ -1,23 +1,5 @@
 # Ty adoption migration plan
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Non-goals](#non-goals)
-- [Assumptions](#assumptions)
-- [Plan](#plan)
-  - [Phase 0: Baseline decisions](#phase-0-baseline-decisions)
-  - [Phase 1: Standards updates](#phase-1-standards-updates)
-  - [Phase 2: Repository enablement](#phase-2-repository-enablement)
-  - [Phase 3: Side-by-side evaluation](#phase-3-side-by-side-evaluation)
-  - [Phase 4: Remediation and alignment](#phase-4-remediation-and-alignment)
-  - [Phase 5: Cutover and cleanup](#phase-5-cutover-and-cleanup)
-- [Acceptance criteria](#acceptance-criteria)
-- [Risks and mitigations](#risks-and-mitigations)
-- [Rollback strategy](#rollback-strategy)
-- [Open questions](#open-questions)
-
 ## Purpose
 
 Adopt `ty` as a peer type checker alongside `mypy`, run both in parallel long

--- a/docs/development/python/type-hints.md
+++ b/docs/development/python/type-hints.md
@@ -1,12 +1,5 @@
 # Python Type Hints
 
-## Table of Contents
-
-- [Rule](#rule)
-- [Rationale](#rationale)
-- [Type checker parity protocol](#type-checker-parity-protocol)
-- [Examples](#examples)
-
 ## Rule
 
 All public functions and methods must have complete type hints. Enforce this

--- a/docs/development/python/version-management.md
+++ b/docs/development/python/version-management.md
@@ -1,24 +1,5 @@
 # Python Version Management
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Core principles](#core-principles)
-- [Sources of truth](#sources-of-truth)
-- [Upgrade workflow](#upgrade-workflow)
-  - [Patch-level](#patch-level)
-  - [Minor- or major-level](#minor--or-major-level)
-  - [Minor release preview (dual-CI)](#minor-release-preview-dual-ci)
-  - [Cutover criteria](#cutover-criteria)
-  - [Stability tracking](#stability-tracking)
-- [Host decoupling and parity](#host-decoupling-and-parity)
-  - [Parity requirements](#parity-requirements)
-  - [Decoupling strategies](#decoupling-strategies)
-- [Enforcement](#enforcement)
-- [Examples (TODO)](#examples-todo)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define a repeatable Python version strategy that keeps runtime behavior stable

--- a/docs/development/runtime-version-support-policy.md
+++ b/docs/development/runtime-version-support-policy.md
@@ -1,18 +1,5 @@
 # Runtime Version Support Policy
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Support tiers](#support-tiers)
-- [CI matrix mapping](#ci-matrix-mapping)
-- [Application versus library scope](#application-versus-library-scope)
-- [Drop criteria](#drop-criteria)
-- [Drop procedure](#drop-procedure)
-- [Language lifecycle references](#language-lifecycle-references)
-- [Related documents](#related-documents)
-
 ## Purpose
 
 Define a tiered runtime version support policy that balances forward progress

--- a/docs/development/shell/naming-conventions.md
+++ b/docs/development/shell/naming-conventions.md
@@ -1,17 +1,5 @@
 # Shell Naming Conventions
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Baseline Conventions](#baseline-conventions)
-- [Variable Naming Rules](#variable-naming-rules)
-  - [1. Minimum Length: 3+ Characters](#1-minimum-length-3-characters)
-  - [2. Complete English Words](#2-complete-english-words)
-  - [3. Namespace Collision Handling](#3-namespace-collision-handling)
-  - [4. Boolean Variables](#4-boolean-variables)
-  - [5. Collections: Plural vs. Singular](#5-collections-plural-vs-singular)
-  - [6. Consistency Rules](#6-consistency-rules)
-
 ## Purpose
 
 Provide naming rules that optimize for clarity, consistency, and accessibility.

--- a/docs/development/shell/overview.md
+++ b/docs/development/shell/overview.md
@@ -1,13 +1,5 @@
 # Shell Scripting Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Principles](#core-principles)
-- [Tooling Expectations](#tooling-expectations)
-- [CI Gates](#ci-gates)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define consistent shell scripting standards that emphasize safety,

--- a/docs/foundation/agent-boot-banner.md
+++ b/docs/foundation/agent-boot-banner.md
@@ -1,12 +1,5 @@
 # Agent boot banner
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Banner text](#banner-text)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Provide a standard banner that reaffirms the interaction contract at session

--- a/docs/foundation/agent-guardrails.md
+++ b/docs/foundation/agent-guardrails.md
@@ -1,12 +1,5 @@
 # Agent guardrails
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Guardrails](#guardrails)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Provide a short, high-signal list of non-negotiable agent constraints that must

--- a/docs/foundation/agent-pre-response-checklist.md
+++ b/docs/foundation/agent-pre-response-checklist.md
@@ -1,12 +1,5 @@
 # Agent pre-response checklist
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Checklist](#checklist)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Provide a minimal checklist to detect drift toward assumption-light or

--- a/docs/foundation/agent-skills.md
+++ b/docs/foundation/agent-skills.md
@@ -1,14 +1,5 @@
 # Agent skills
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Repository-local skills](#repository-local-skills)
-- [Shared skills library](#shared-skills-library)
-- [Registration and loading](#registration-and-loading)
-- [Startup reporting](#startup-reporting)
-
 ## Purpose
 
 Define how skills are stored, imported, and referenced so repositories avoid

--- a/docs/foundation/ai-assisted-development-loop.md
+++ b/docs/foundation/ai-assisted-development-loop.md
@@ -1,17 +1,5 @@
 # AI-Assisted Development Loop
 
-## Table of Contents
-
-- [Status](#status)
-- [1. Purpose](#1-purpose)
-- [2. Initial Conditions](#2-initial-conditions)
-- [3. Core Insight](#3-core-insight)
-- [4. The Loop](#4-the-loop)
-- [5. What the AI Is Not Doing](#5-what-the-ai-is-not-doing)
-- [6. Velocity and Control](#6-velocity-and-control)
-- [7. Intended Use](#7-intended-use)
-- [Closing Note](#closing-note)
-
 ## Status
 
 Frozen v0.1 snapshot

--- a/docs/foundation/ai-code-review-guidelines.md
+++ b/docs/foundation/ai-code-review-guidelines.md
@@ -1,26 +1,5 @@
 # AI Code Review Guidelines
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Philosophy](#core-philosophy)
-  - [1. Design First, Tests Second](#1-design-first-tests-second)
-  - [2. Passing Tests Are Necessary, Not Sufficient](#2-passing-tests-are-necessary-not-sufficient)
-- [Reviewer Role Definition](#reviewer-role-definition)
-- [Review Focus Areas](#review-focus-areas)
-  - [1. Namespace Integrity](#1-namespace-integrity)
-  - [2. Contract Alignment Across Layers](#2-contract-alignment-across-layers)
-  - [3. Architectural Coherence](#3-architectural-coherence)
-  - [4. Tooling Integration as Architecture](#4-tooling-integration-as-architecture)
-  - [5. Survivability Without Original Author](#5-survivability-without-original-author)
-- [Explicit Non-Goals](#explicit-non-goals)
-- [Review Output Expectations](#review-output-expectations)
-- [Guiding Principle](#guiding-principle)
-- [Appendix A: Common Failure Modes](#appendix-a-common-failure-modes)
-  - [A.1 Test-Driven Namespace Drift](#a1-test-driven-namespace-drift)
-  - [A.2 Tests as Architectural Camouflage](#a2-tests-as-architectural-camouflage)
-- [Status](#status)
-
 ## Purpose
 
 Define how AI-assisted code reviews are performed.

--- a/docs/foundation/architecture-standards.md
+++ b/docs/foundation/architecture-standards.md
@@ -1,15 +1,5 @@
 # Architecture Standards and Conventions
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Canonical vs. Derivative Artifacts](#canonical-vs-derivative-artifacts)
-- [Proprietary Tools and Formats](#proprietary-tools-and-formats)
-- [File Format Standards](#file-format-standards)
-- [Tool and Domain Independence](#tool-and-domain-independence)
-- [Versioning and Stability](#versioning-and-stability)
-- [Scope Notes](#scope-notes)
-
 ## Purpose
 
 Define architectural standards and constraints that govern design and

--- a/docs/foundation/cognitive-drift-log.md
+++ b/docs/foundation/cognitive-drift-log.md
@@ -1,12 +1,5 @@
 # Cognitive drift log
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Template](#template)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Provide a minimal log template for recording concerning or hard failures.

--- a/docs/foundation/cognitive-regression-tests.md
+++ b/docs/foundation/cognitive-regression-tests.md
@@ -1,13 +1,5 @@
 # Cognitive regression tests
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Categories](#categories)
-- [Failure criteria](#failure-criteria)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Define regression tests that detect drift toward polite, assumption-light, or

--- a/docs/foundation/interaction-contract-brief.md
+++ b/docs/foundation/interaction-contract-brief.md
@@ -1,18 +1,5 @@
 # Interaction contract (brief)
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Normative language](#normative-language)
-- [Core role](#core-role)
-- [Optimization invariants](#optimization-invariants)
-- [Communication requirements](#communication-requirements)
-- [Failure signaling](#failure-signaling)
-- [RTFM protocol](#rtfm-protocol)
-- [Anti-goals](#anti-goals)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Define a concise operating contract for adversarial, durability-focused AI

--- a/docs/foundation/interaction-contract.md
+++ b/docs/foundation/interaction-contract.md
@@ -1,19 +1,5 @@
 # Interaction contract
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Normative language](#normative-language)
-- [Core role](#core-role)
-- [Optimization invariants](#optimization-invariants)
-- [Communication requirements](#communication-requirements)
-- [Failure signaling](#failure-signaling)
-- [RTFM protocol](#rtfm-protocol)
-- [Anti-goals](#anti-goals)
-- [Agent self-check rubric](#agent-self-check-rubric)
-- [Prompt shortcuts](#prompt-shortcuts)
-
 ## Purpose
 
 Define the operating contract between a user and an AI assistant acting as an

--- a/docs/foundation/markdown-standards.md
+++ b/docs/foundation/markdown-standards.md
@@ -1,18 +1,5 @@
 # Markdown Standards
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [File Naming and Placement](#file-naming-and-placement)
-- [Structure and Headings](#structure-and-headings)
-- [Table of Contents Rules](#table-of-contents-rules)
-- [Formatting Conventions](#formatting-conventions)
-- [Links and References](#links-and-references)
-- [Code Blocks](#code-blocks)
-- [Validation](#validation)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Define consistent Markdown conventions for clarity, durability, and easy
@@ -46,7 +33,8 @@ explicitly state otherwise.
 - Use GitHub-style anchor links.
 - **Exception**: Pages built by documentation site generators (Sphinx, MkDocs,
   etc.) are exempt from the Table of Contents requirement because those tools
-  provide integrated navigation.
+  provide integrated navigation. The lint script detects MkDocs doc trees
+  automatically when `mkdocs.yml` exists at the repository root.
 
 ## Formatting Conventions
 
@@ -81,5 +69,5 @@ explicitly state otherwise.
 
 ## Maintenance
 
-- Update the Table of Contents when headings change.
+- Update the Table of Contents when headings change (non-docsite files only).
 - Keep documents current; stale guidance should be revised or removed.

--- a/docs/foundation/overview.md
+++ b/docs/foundation/overview.md
@@ -1,12 +1,5 @@
 # Foundation Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Document map](#document-map)
-- [When to use each summary protocol](#when-to-use-each-summary-protocol)
-
 ## Purpose
 
 Provide a single entry point for foundational standards that apply across

--- a/docs/foundation/standards-bootstrap-protocol.md
+++ b/docs/foundation/standards-bootstrap-protocol.md
@@ -1,15 +1,5 @@
 # Standards bootstrap protocol
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Inputs](#inputs)
-- [Protocol](#protocol)
-- [Required output](#required-output)
-- [Failure modes](#failure-modes)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Provide a deterministic, AGENTS-only startup procedure for loading standards

--- a/docs/foundation/summarize-decisions-protocol.md
+++ b/docs/foundation/summarize-decisions-protocol.md
@@ -1,19 +1,5 @@
 # Summarize decisions protocol
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Prompt shortcuts](#prompt-shortcuts)
-- [Input rules](#input-rules)
-- [Output structure](#output-structure)
-- [Section requirements](#section-requirements)
-- [Implicitly converged decisions](#implicitly-converged-decisions)
-- [Optional sections](#optional-sections)
-- [Style and fidelity rules](#style-and-fidelity-rules)
-- [Failure modes](#failure-modes)
-
 ## Purpose
 
 Define how to summarize a discussion into durable documentation that preserves

--- a/docs/foundation/summarize-operations-protocol.md
+++ b/docs/foundation/summarize-operations-protocol.md
@@ -1,21 +1,5 @@
 # Summarize operations protocol
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Prompt shortcuts](#prompt-shortcuts)
-- [Input rules](#input-rules)
-- [Output location and naming](#output-location-and-naming)
-- [Output structure](#output-structure)
-- [Section requirements](#section-requirements)
-- [Evidence capture rules](#evidence-capture-rules)
-- [Timestamp requirements](#timestamp-requirements)
-- [Optional sections](#optional-sections)
-- [Style and fidelity rules](#style-and-fidelity-rules)
-- [Failure modes](#failure-modes)
-
 ## Purpose
 
 Define how to summarize operational work into durable documentation that

--- a/docs/foundation/summarize-stream-of-consciousness-protocol.md
+++ b/docs/foundation/summarize-stream-of-consciousness-protocol.md
@@ -1,16 +1,5 @@
 # Summarize stream of consciousness protocol
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Definitions](#definitions)
-- [Prompt shortcuts](#prompt-shortcuts)
-- [Protocol states](#protocol-states)
-- [Capture rules](#capture-rules)
-- [Post-processing output](#post-processing-output)
-- [Failure modes](#failure-modes)
-
 ## Purpose
 
 Define a toggleable protocol for capturing unfiltered, unstructured thoughts

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,5 @@
 # Standards and Conventions
 
-## Table of Contents
-
-- [Sections](#sections)
-
 ## Sections
 
 This site is the canonical reference for development standards,

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,14 +1,5 @@
 # Standards and Conventions Repository Standards
 
-## Table of Contents
-
-- [AI co-authors](#ai-co-authors)
-- [Repository profile](#repository-profile)
-- [Validation policy](#validation-policy)
-- [External tooling dependencies](#external-tooling-dependencies)
-- [CI gates](#ci-gates)
-- [Local deviations](#local-deviations)
-
 ## AI co-authors
 
 - Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>

--- a/docs/repository/local-validation-scripts.md
+++ b/docs/repository/local-validation-scripts.md
@@ -1,14 +1,5 @@
 # Local Validation Scripts
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Requirements](#requirements)
-- [CI parity](#ci-parity)
-- [Per-ecosystem examples](#per-ecosystem-examples)
-- [Ecosystem-specific standards](#ecosystem-specific-standards)
-
 ## Purpose
 
 Define the required behavior for a canonical validation script that runs all

--- a/docs/repository/overview.md
+++ b/docs/repository/overview.md
@@ -1,11 +1,5 @@
 # Repository Standards Overview
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope](#scope)
-- [Document Map](#document-map)
-
 ## Purpose
 
 Define reusable repository structure standards that keep projects durable,

--- a/docs/repository/repository-structure.md
+++ b/docs/repository/repository-structure.md
@@ -1,15 +1,5 @@
 # Repository Structure Standards
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Core Principles](#core-principles)
-- [Top-Level Layout](#top-level-layout)
-- [Tests](#tests)
-- [Documentation and Decision Records](#documentation-and-decision-records)
-- [Examples](#examples)
-- [Revisiting the Structure](#revisiting-the-structure)
-
 ## Purpose
 
 Provide a default repository layout that is explicit, discoverable, and easy to

--- a/docs/repository/shared-tooling-sync.md
+++ b/docs/repository/shared-tooling-sync.md
@@ -1,17 +1,5 @@
 # Shared Tooling Sync
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Architecture](#architecture)
-- [Managed scripts](#managed-scripts)
-- [Sync mechanism](#sync-mechanism)
-- [Staleness gate](#staleness-gate)
-- [Handling staleness gate failures](#handling-staleness-gate-failures)
-- [Updating the canonical source](#updating-the-canonical-source)
-- [Adding a new managed script](#adding-a-new-managed-script)
-- [Bootstrapping a new repository](#bootstrapping-a-new-repository)
-
 ## Purpose
 
 Shared scripts (lint, git hooks, dev tooling) are copied across all

--- a/docs/research/eu-canada-github-aws-alternatives.md
+++ b/docs/research/eu-canada-github-aws-alternatives.md
@@ -1,23 +1,5 @@
 # EU and Canada alternatives to GitHub and AWS (non-US ownership)
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Scope and constraints](#scope-and-constraints)
-- [Evaluation criteria](#evaluation-criteria)
-- [Findings](#findings)
-  - [Sovereignty drivers and policy signal](#sovereignty-drivers-and-policy-signal)
-  - [US jurisdiction exposure and transfer risk](#us-jurisdiction-exposure-and-transfer-risk)
-  - [Git hosting](#git-hosting)
-  - [CI and CD](#ci-and-cd)
-  - [Managed PostgreSQL and API hosting](#managed-postgresql-and-api-hosting)
-- [Recommendations](#recommendations)
-  - [EU-based recommendation](#eu-based-recommendation)
-  - [Canada-based recommendation](#canada-based-recommendation)
-- [Migration path (next 12 months)](#migration-path-next-12-months)
-- [Risks and open questions](#risks-and-open-questions)
-- [References](#references)
-
 ## Purpose
 
 Provide a concise, decision-ready report on non-US-owned alternatives to

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,14 +1,5 @@
 # Standards and Conventions Reference
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Requirement](#requirement)
-- [Includes](#includes)
-- [Project-specific overlay](#project-specific-overlay)
-- [Template](#template)
-- [Maintenance](#maintenance)
-
 ## Purpose
 
 Provide a required, repository-local entry point that references the canonical

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -3,19 +3,29 @@ set -euo pipefail
 
 # Collect standard docs (structural checks + markdownlint).
 files=()
-while IFS= read -r file; do
-  files+=("$file")
-done < <(find docs -path docs/sphinx -prune -o -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+
+# Doc-site directories whose files get markdownlint only — structural checks
+# like Table of Contents and single-H1 do not apply to pages built by
+# documentation site generators such as Sphinx, MkDocs, etc.
+docsite_dirs=(docs/sphinx docs/site)
+
+# When mkdocs.yml exists at repo root, docs/ is the MkDocs content directory.
+# All files under docs/ are doc-site pages and skip structural checks.
+if [[ -f mkdocs.yml ]]; then
+  docsite_dirs+=("docs")
+else
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(find docs -path docs/sphinx -prune -o -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+fi
 
 if [[ -f README.md ]]; then
   files+=("README.md")
 fi
 
-# Collect doc-site files (markdownlint only — structural checks like
-# Table of Contents and single-H1 do not apply to pages built by
-# documentation site generators such as Sphinx, MkDocs, etc.).
+# Collect doc-site files (markdownlint only).
 docsite_files=()
-for docsite_dir in docs/sphinx docs/site; do
+for docsite_dir in "${docsite_dirs[@]}"; do
   if [[ -d "$docsite_dir" ]]; then
     while IFS= read -r file; do
       docsite_files+=("$file")


### PR DESCRIPTION
## Summary

- Update lint script to detect MkDocs doc trees (via `mkdocs.yml`) and skip structural checks (TOC, single-H1, heading hierarchy) for `docs/` files
- Remove manually-maintained `## Table of Contents` sections from all 65 docs files — MkDocs Material provides native navigation and per-page TOC
- Clarify the MkDocs auto-detection in the markdown standard

Closes #243

Docs-only: tests skipped

### Files changed

- `scripts/lint/markdown-standards.sh` — MkDocs detection logic
- `docs/foundation/markdown-standards.md` — wording update
- 64 additional `docs/**/*.md` files — TOC section removal
