### PR TITLE
chore: update CI toolchain dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,12 +16,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install mkdocs-material mike
       - name: Configure git identity
         run: |

--- a/.github/workflows/standards-gates.yml
+++ b/.github/workflows/standards-gates.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v4 to v6 in both `docs.yml` and `standards-gates.yml`
- Bump `actions/setup-python` from v5 to v6 in `docs.yml`
- Bump Python version from 3.12 to 3.13 in `docs.yml`

## Test plan

- [x] CI passes on the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
