### PR TITLE
chore: bump docs build Python to 3.14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: pip install mkdocs-material mike
       - name: Configure git identity
         run: |


### PR DESCRIPTION
## Summary

- Bump Python runtime from 3.13 to 3.14 for the docs build workflow
- 3.14 is the current active bugfix release; no compatibility concern for mkdocs-material/mike

Ref #243

Docs-only: tests skipped

### Files changed

- `.github/workflows/docs.yml`
