### PR TITLE
fix: remove edited trigger from standards-gates to prevent auto-merge race

### DIFF
--- a/.github/workflows/standards-gates.yml
+++ b/.github/workflows/standards-gates.yml
@@ -2,7 +2,7 @@ name: Standards Gates
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
 
 jobs:
   standards-gates:


### PR DESCRIPTION
## Summary

- Remove `edited` from `pull_request.types` in `standards-gates.yml` to prevent a duplicate CI run that races with auto-merge

The `edited` event fires when auto-merge is enabled on a PR, triggering a second workflow run for the same commit. Auto-merge considers the required check satisfied as soon as one passing run exists, so it merges before the second run completes. Observed on PR #249 where the second run failed after the PR was already merged.

Closes #255

## Test plan

- [ ] Open a PR and enable auto-merge; confirm only one Standards Gates run triggers
- [ ] Edit a PR title/body; confirm no new CI run triggers
