### PR TITLE
docs: add sub-issues API procedure

### DIFF
--- a/docs/site/docs/code-management/github-issues.md
+++ b/docs/site/docs/code-management/github-issues.md
@@ -78,9 +78,30 @@ Create a sub-issue when:
 
 Sub-issue rules:
 
-- Link each sub-issue to its parent (task list or issue relationship).
+- Link each sub-issue to its parent using the sub-issues API (see below).
 - The PR should close the sub-issue, not the parent, unless the PR completes
   the parent’s full scope.
+
+### Linking a sub-issue via the API
+
+Creating a sub-issue relationship is a two-step process:
+
+1. **Get the child issue’s database ID** (this is the numeric ID, not the
+   issue number):
+
+   ```bash
+   gh api repos/{owner}/{repo}/issues/{child_number} --jq ‘.id’
+   ```
+
+2. **Link the child to the parent**:
+
+   ```bash
+   gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues \
+     --method POST -F sub_issue_id={database_id}
+   ```
+
+Use `-F` (not `-f`) for `sub_issue_id` — the API requires an integer, and
+`-f` sends a string.
 
 ## Closing behavior
 

--- a/docs/site/docs/code-management/github-projects.md
+++ b/docs/site/docs/code-management/github-projects.md
@@ -296,7 +296,8 @@ Create a sub-issue in each mq-rest-admin repo:
 >
 > **Acceptance criteria**: shared-tooling updated, CI passing.
 
-Link each as a sub-issue of the parent.
+Link each as a sub-issue of the parent using the
+[sub-issues API](github-issues.md#linking-a-sub-issue-via-the-api).
 
 #### Step 3: Set fields on all issues
 


### PR DESCRIPTION
# Pull Request

## Summary

- Document the two-step sub-issues API procedure (get database ID, then link) in github-issues.md and add a cross-reference from github-projects.md

## Issue Linkage

- Fixes #274

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/code-management/github-issues.md
- docs/site/docs/code-management/github-projects.md

## Notes

- -
