### PR TITLE
docs: document that re-running CI does not refresh PR event payload

### DIFF
--- a/docs/site/docs/code-management/pull-request-workflow.md
+++ b/docs/site/docs/code-management/pull-request-workflow.md
@@ -139,6 +139,12 @@ If any hard-gate check fails:
 If a soft-gate check fails, either fix it immediately or document the failure
 with rationale and follow-up tracking before submission.
 
+**Event payload is fixed at push time.** Re-running a workflow does not refresh
+the pull request event payload. If a CI check fails because of PR metadata
+(e.g., missing issue linkage in the PR body), editing the PR body and re-running
+the workflow will not help — the re-run uses the original payload. Push a new
+commit to trigger a fresh workflow run with the updated event data.
+
 Common mistakes to avoid:
 
 - "I only changed one area, so I only ran those tests"

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -55,6 +55,10 @@ always enabled; CI gates are the sole merge authority.
 2. Enable auto-merge immediately. Do not attempt manual merge.
 3. Wait for CI to pass and auto-merge to complete.
 
+If a CI check fails due to PR metadata (e.g., missing issue linkage), editing
+the PR body and re-running the workflow will not fix it — re-runs use the
+original event payload. Push a new commit to trigger a fresh workflow run.
+
 ## Finalization
 
 After the PR merges, run `scripts/dev/finalize_repo.sh` from the repository


### PR DESCRIPTION
# Pull Request

## Summary

- Add event payload caveat to pull-request-workflow.md and pr-workflow skill — re-runs use the original payload, so editing the PR body requires a new commit to trigger fresh validation

## Issue Linkage

- Fixes #275

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/code-management/pull-request-workflow.md
- skills/pr-workflow/SKILL.md

## Notes

- -
