### PR TITLE
fix(ci): set commit-message lint cutoff to skip pre-conventional-commits history

### DIFF
--- a/.github/workflows/standards-gates.yml
+++ b/.github/workflows/standards-gates.yml
@@ -24,6 +24,8 @@ jobs:
         run: scripts/lint/markdown-standards.sh
 
       - name: Lint commit messages
+        env:
+          COMMIT_CUTOFF_SHA: 3a49262
         run: |
           base_sha=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
           head_sha=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
# Pull Request

## Summary

- Set commit-message lint cutoff to skip pre-conventional-commits history

## Issue Linkage

- Ref #286

## Testing

Docs-only: tests skipped

Changed files:
- .github/workflows/standards-gates.yml

## Notes

- -
