### PR TITLE
docs: document SonarCloud as optional advisory CI gate

### DIFF
--- a/docs/site/docs/code-management/source-control-guidelines.md
+++ b/docs/site/docs/code-management/source-control-guidelines.md
@@ -137,6 +137,30 @@ so failing GitHub Actions block PR merges.
 Each repository must also document which hard gates apply per branch. Some
 hard gates may be develop-only, while others must run on all eternal branches.
 
+#### SonarQube Cloud (soft gate, limited beta)
+
+SonarQube Cloud (SonarCloud) provides cross-language static analysis for code
+quality, security vulnerabilities, and maintainability. It is currently deployed
+as an **optional, advisory soft gate** in limited beta on the mq-rest-admin
+language implementation repos (Python, Go, Java).
+
+SonarCloud's free tier does not support custom quality gates, so the integration
+provides informational analysis rather than enforcement. Language-specific
+tooling (ruff, mypy, golangci-lint, spotbugs, etc.) remains the primary
+enforcement mechanism and the hard gate for code quality.
+
+SonarCloud runs in two patterns per repository:
+
+- **PR analysis** — a `sonarcloud` job in `ci.yml` posts a quality gate comment
+  on each pull request.
+- **Post-merge baseline** — a dedicated `sonarcloud.yml` workflow triggered on
+  `push` to `develop` keeps the SonarCloud project dashboard current.
+
+SonarCloud is not a required status check on any branch. It must not block PR
+merges. The composite action is defined in the
+[standard-actions](https://github.com/wphillipmoore/standard-actions) shared
+actions library at `actions/quality/sonarcloud`.
+
 ### Docs-only CI skip policy
 
 Repositories must define a docs-only allowlist (for example, `docs/**`,

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -58,6 +58,23 @@ required tools explicitly.
 Documentation repositories must include markdownlint in their external tooling
 list.
 
+### SonarQube Cloud (SonarCloud)
+
+SonarCloud is a cloud-hosted static analysis service used as an optional,
+advisory quality gate. It is currently in limited beta on the mq-rest-admin
+language implementation repos (Python, Go, Java).
+
+SonarCloud requires:
+
+- A SonarCloud account linked to the GitHub organization or personal account.
+- A `SONAR_TOKEN` repository secret on each repo that uses the integration.
+- Automatic analysis disabled per project in SonarCloud (CI-based analysis and
+  automatic analysis cannot run simultaneously).
+
+SonarCloud is consumed via the `quality/sonarcloud` composite action in the
+shared actions library. No local installation is required — the scanner runs
+entirely in CI.
+
 ### Baseline automation assumptions
 
 For AI-assisted workflows in this environment, assume the following are


### PR DESCRIPTION
# Pull Request

## Summary

- Document SonarCloud as optional advisory CI gate in source-control-guidelines and environment-and-tooling

## Issue Linkage

- Fixes #304

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/code-management/source-control-guidelines.md
- docs/site/docs/development/environment-and-tooling.md

## Notes

- -