### PR TITLE
docs: add Qlty Cloud (Code Climate) to standards documentation

### DIFF
--- a/docs/site/docs/code-management/source-control-guidelines.md
+++ b/docs/site/docs/code-management/source-control-guidelines.md
@@ -161,6 +161,32 @@ merges. The composite action is defined in the
 [standard-actions](https://github.com/wphillipmoore/standard-actions) shared
 actions library at `actions/quality/sonarcloud`.
 
+#### Qlty Cloud (soft gate, limited beta)
+
+Qlty Cloud (formerly Code Climate) provides coverage tracking, trend analysis,
+and PR coverage comments. It is currently deployed as an **optional, advisory
+soft gate** in limited beta on the mq-rest-admin language implementation repos
+(Python, Go, Java).
+
+Qlty Cloud's free tier provides 500 analysis minutes per month for open-source
+projects. Language-specific tooling remains the primary enforcement mechanism for
+coverage thresholds.
+
+Qlty Cloud runs in two patterns per repository:
+
+- **PR analysis** — a `codeclimate` job in `ci.yml` uploads coverage and posts a
+  coverage comment on each pull request.
+- **Post-merge baseline** — a dedicated `codeclimate.yml` workflow triggered on
+  `push` to `develop` keeps the Qlty Cloud dashboard current.
+
+Qlty Cloud uses OIDC authentication — no tokens or secrets are required. The
+calling workflow must include `id-token: write` in its permissions block.
+
+Qlty Cloud is not a required status check on any branch. It must not block PR
+merges. The composite action is defined in the
+[standard-actions](https://github.com/wphillipmoore/standard-actions) shared
+actions library at `actions/quality/codeclimate`.
+
 ### Docs-only CI skip policy
 
 Repositories must define a docs-only allowlist (for example, `docs/**`,

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -75,6 +75,26 @@ SonarCloud is consumed via the `quality/sonarcloud` composite action in the
 shared actions library. No local installation is required — the scanner runs
 entirely in CI.
 
+### Qlty Cloud (Code Climate)
+
+Qlty Cloud (formerly Code Climate) is a cloud-hosted coverage tracking service
+used as an optional, advisory quality gate. It is currently in limited beta on
+the mq-rest-admin language implementation repos (Python, Go, Java).
+
+Qlty Cloud requires:
+
+- The Qlty Cloud GitHub App installed on the GitHub account or organization.
+- Each repository imported in Qlty Cloud at [qlty.io](https://qlty.io).
+- Automatic analysis disabled per project if using CI-based coverage upload
+  exclusively.
+
+Qlty Cloud uses OIDC authentication — no tokens or secrets are required. The
+calling workflow must include `id-token: write` in its permissions block.
+
+Qlty Cloud is consumed via the `quality/codeclimate` composite action in the
+shared actions library. No local installation is required — coverage upload runs
+entirely in CI.
+
 ### Baseline automation assumptions
 
 For AI-assisted workflows in this environment, assume the following are


### PR DESCRIPTION
# Pull Request

## Summary

- Add Qlty Cloud (Code Climate) as soft gate and external service alongside SonarCloud

## Issue Linkage

- Fixes #308

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/code-management/source-control-guidelines.md
- docs/site/docs/development/environment-and-tooling.md

## Notes

- -