### PR TITLE
docs: remove SonarCloud and Qlty Cloud documentation

### DIFF
--- a/docs/site/docs/code-management/source-control-guidelines.md
+++ b/docs/site/docs/code-management/source-control-guidelines.md
@@ -137,56 +137,6 @@ so failing GitHub Actions block PR merges.
 Each repository must also document which hard gates apply per branch. Some
 hard gates may be develop-only, while others must run on all eternal branches.
 
-#### SonarQube Cloud (soft gate, limited beta)
-
-SonarQube Cloud (SonarCloud) provides cross-language static analysis for code
-quality, security vulnerabilities, and maintainability. It is currently deployed
-as an **optional, advisory soft gate** in limited beta on the mq-rest-admin
-language implementation repos (Python, Go, Java).
-
-SonarCloud's free tier does not support custom quality gates, so the integration
-provides informational analysis rather than enforcement. Language-specific
-tooling (ruff, mypy, golangci-lint, spotbugs, etc.) remains the primary
-enforcement mechanism and the hard gate for code quality.
-
-SonarCloud runs in two patterns per repository:
-
-- **PR analysis** — a `sonarcloud` job in `ci.yml` posts a quality gate comment
-  on each pull request.
-- **Post-merge baseline** — a dedicated `sonarcloud.yml` workflow triggered on
-  `push` to `develop` keeps the SonarCloud project dashboard current.
-
-SonarCloud is not a required status check on any branch. It must not block PR
-merges. The composite action is defined in the
-[standard-actions](https://github.com/wphillipmoore/standard-actions) shared
-actions library at `actions/quality/sonarcloud`.
-
-#### Qlty Cloud (soft gate, limited beta)
-
-Qlty Cloud (formerly Code Climate) provides coverage tracking, trend analysis,
-and PR coverage comments. It is currently deployed as an **optional, advisory
-soft gate** in limited beta on the mq-rest-admin language implementation repos
-(Python, Go, Java).
-
-Qlty Cloud's free tier provides 500 analysis minutes per month for open-source
-projects. Language-specific tooling remains the primary enforcement mechanism for
-coverage thresholds.
-
-Qlty Cloud runs in two patterns per repository:
-
-- **PR analysis** — a `codeclimate` job in `ci.yml` uploads coverage and posts a
-  coverage comment on each pull request.
-- **Post-merge baseline** — a dedicated `codeclimate.yml` workflow triggered on
-  `push` to `develop` keeps the Qlty Cloud dashboard current.
-
-Qlty Cloud uses OIDC authentication — no tokens or secrets are required. The
-calling workflow must include `id-token: write` in its permissions block.
-
-Qlty Cloud is not a required status check on any branch. It must not block PR
-merges. The composite action is defined in the
-[standard-actions](https://github.com/wphillipmoore/standard-actions) shared
-actions library at `actions/quality/codeclimate`.
-
 ### Docs-only CI skip policy
 
 Repositories must define a docs-only allowlist (for example, `docs/**`,

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -58,43 +58,6 @@ required tools explicitly.
 Documentation repositories must include markdownlint in their external tooling
 list.
 
-### SonarQube Cloud (SonarCloud)
-
-SonarCloud is a cloud-hosted static analysis service used as an optional,
-advisory quality gate. It is currently in limited beta on the mq-rest-admin
-language implementation repos (Python, Go, Java).
-
-SonarCloud requires:
-
-- A SonarCloud account linked to the GitHub organization or personal account.
-- A `SONAR_TOKEN` repository secret on each repo that uses the integration.
-- Automatic analysis disabled per project in SonarCloud (CI-based analysis and
-  automatic analysis cannot run simultaneously).
-
-SonarCloud is consumed via the `quality/sonarcloud` composite action in the
-shared actions library. No local installation is required — the scanner runs
-entirely in CI.
-
-### Qlty Cloud (Code Climate)
-
-Qlty Cloud (formerly Code Climate) is a cloud-hosted coverage tracking service
-used as an optional, advisory quality gate. It is currently in limited beta on
-the mq-rest-admin language implementation repos (Python, Go, Java).
-
-Qlty Cloud requires:
-
-- The Qlty Cloud GitHub App installed on the GitHub account or organization.
-- Each repository imported in Qlty Cloud at [qlty.io](https://qlty.io).
-- Automatic analysis disabled per project if using CI-based coverage upload
-  exclusively.
-
-Qlty Cloud uses OIDC authentication — no tokens or secrets are required. The
-calling workflow must include `id-token: write` in its permissions block.
-
-Qlty Cloud is consumed via the `quality/codeclimate` composite action in the
-shared actions library. No local installation is required — coverage upload runs
-entirely in CI.
-
 ### Baseline automation assumptions
 
 For AI-assisted workflows in this environment, assume the following are


### PR DESCRIPTION
# Pull Request

## Summary

- Remove SonarCloud and Qlty Cloud documentation sections

## Issue Linkage

- Ref wphillipmoore/standard-actions#93

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/code-management/source-control-guidelines.md
- docs/site/docs/development/environment-and-tooling.md

## Notes

- -