### PR TITLE
chore(docs): reposition Releases in MkDocs nav

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -54,6 +54,9 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Releases:
+      - Release Notes: releases/index.md
+      - Changelog: changelog.md
   - Standards:
       - Overview: standards/overview.md
       - Markdown Standards: standards/markdown-standards.md
@@ -133,6 +136,3 @@ nav:
           - Conventions: development/database/conventions.md
   - Research:
       - EU/Canada Alternatives: research/eu-canada-github-aws-alternatives.md
-  - Releases:
-      - Release Notes: releases/index.md
-      - Changelog: changelog.md


### PR DESCRIPTION
# Pull Request

## Summary

- Reposition Releases to nav position 2 for prominence

## Issue Linkage

- Fixes #323

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/mkdocs.yml

## Notes

- -