### PR TITLE
refactor: remove docs-only CI skip policy and exception references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,6 @@ The include directives above load the full repository standards. Key highlights 
 
 **Branching**: `develop` is the default branch (staging). `main` is the promotion target (live site). All work happens on `feature/*` or `bugfix/*` branches merged to `develop` via PR. Changes reach `main` via promotion PR from `develop`.
 
-**Docs-only exception**: Since this is a documentation-only repository, the docs-only exception applies to all PRs. Local validation is optional per the docs-only rule.
-
 **Validation**: markdownlint is the canonical local validation tool. It must be on PATH (`markdownlint-cli`).
 
 ## File Layout
@@ -229,7 +227,7 @@ st-commit --type fix --message "correct markdown lint config" --body "Aligned wi
 
 ```bash
 st-submit-pr --issue 42 --summary "Update branching model standards"
-st-submit-pr --issue 42 --linkage Ref --summary "Clarify AI agent guidelines" --docs-only
+st-submit-pr --issue 42 --linkage Ref --summary "Clarify AI agent guidelines"
 st-submit-pr --issue 42 --summary "Add deprecation triage skill" --notes "New skill loaded by downstream repos"
 ```
 
@@ -238,7 +236,6 @@ st-submit-pr --issue 42 --summary "Add deprecation triage skill" --notes "New sk
 - `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
-- `--docs-only` (optional): applies docs-only testing exception
 - `--dry-run` (optional): print generated PR without executing
 
 ### Post-merge cleanup

--- a/docs/site/docs/ai-agents/behavior/agent-pre-response-checklist.md
+++ b/docs/site/docs/ai-agents/behavior/agent-pre-response-checklist.md
@@ -22,7 +22,7 @@ Use before finalizing any response governed by the interaction contract.
 - Guardrails re-read before any command or edit
   (`docs/ai-agents/behavior/agent-guardrails.md`).
 - Preflight gate emitted before any file edit or git action (branch, issue,
-  docs-only scope, validation policy).
+  validation policy).
 - For documentation repositories, markdownlint is required. Do not ask for
   additional validation unless the repository documents it.
 - No silent guessing of material facts.

--- a/docs/site/docs/ai-agents/workflows/standards-bootstrap-protocol.md
+++ b/docs/site/docs/ai-agents/workflows/standards-bootstrap-protocol.md
@@ -42,7 +42,6 @@ Before any edits or commands, record a short "standards snapshot" that states:
 
 - repository_type
 - branching_model
-- docs-only scope or exception
 - validation policy (required vs optional, plus canonical command if defined)
 
 If any item is unknown or missing, stop and ask for clarification.

--- a/docs/site/docs/code-management/pull-request-workflow.md
+++ b/docs/site/docs/code-management/pull-request-workflow.md
@@ -10,27 +10,6 @@ definitions.
 Submitting failing PRs wastes reviewer time, pollutes history, and undermines
 confidence in the codebase.
 
-## Docs-Only Exception
-
-Documentation-only changes may skip the unit test suite and coverage checks
-when the diff includes only documentation files.
-
-Define "docs-only" for the repository (for example: files under `docs/` plus
-top-level `README.md` and `CHANGELOG.md`).
-
-When using this exception, explicitly state `Docs-only: tests skipped` in the
-PR description and list the files changed.
-
-Documentation repositories may define "docs-only" as the entire repository and
-require markdownlint. Additional validation is optional unless the repository
-documents a requirement. For documentation repositories with only markdownlint
-required, do not ask for additional validation; proceed with PR submission.
-
-CI workflows must implement the docs-only skip policy in
-[source-control-guidelines.md](source-control-guidelines.md#docs-only-ci-skip-policy).
-Markdownlint and any docs-only validation commands must still run even when
-tests are skipped.
-
 ## Issue linkage
 
 Every pull request must have a primary GitHub issue. If no issue exists,
@@ -76,8 +55,7 @@ commands in the Testing section.
 
 ## Pre-Submission Requirements
 
-Before creating a pull request, all of the following must be met unless the
-docs-only exception applies:
+Before creating a pull request, all of the following must be met:
 
 1. 100 percent unit test success
 2. Coverage must not decline (lines and branches)
@@ -153,7 +131,7 @@ Common mistakes to avoid:
 
 ## Auto-merge policy
 
-Auto-merge is the default for all pull requests, including docs-only changes.
+Auto-merge is the default for all pull requests.
 
 Opt out when a merge must be scheduled or reviewed by adding the label
 `manual-merge` to the pull request. Do not enable auto-merge while that label
@@ -210,6 +188,6 @@ Finalize the PR in this order:
 3. update local copy of the target branch
 4. synchronize the local environment with dependency specifications
 5. delete the local feature branch and prune stale remotes
-6. run final validation (skip for docs-only PRs)
+6. run final validation
 
 Do not reuse old branch names.

--- a/docs/site/docs/code-management/source-control-guidelines.md
+++ b/docs/site/docs/code-management/source-control-guidelines.md
@@ -137,21 +137,6 @@ so failing GitHub Actions block PR merges.
 Each repository must also document which hard gates apply per branch. Some
 hard gates may be develop-only, while others must run on all eternal branches.
 
-### Docs-only CI skip policy
-
-Repositories must define a docs-only allowlist (for example, `docs/**`,
-`README.md`, and `CHANGELOG.md`). `.github/**` is not docs-only.
-
-CI workflows must include a docs-only detection job that computes
-`docs_only=true|false` based on the PR diff against the allowlist and exposes it
-as a workflow output.
-
-When `docs_only` is `true`, skip test and version-validation jobs by gating
-them with the docs-only output. Dependency audits should still run by default;
-if a repository chooses to skip them, it must document the exception.
-
-Markdownlint and any docs-only validation commands must still run.
-
 ### Local enforcement hooks
 
 Use local Git hooks to fail closed on branch protection and naming rules that

--- a/docs/site/docs/code-management/workflow-runbooks.md
+++ b/docs/site/docs/code-management/workflow-runbooks.md
@@ -54,9 +54,7 @@ Applies to all repositories governed by these standards.
 2. Push the branch to the remote.
 3. Create the pull request using the repository template.
 4. Link the primary issue in the PR description.
-5. If the work is docs-only, state "Docs-only: tests skipped" and list changed
-   files.
-6. Enable auto-merge unless the repository requires manual merge.
+5. Enable auto-merge unless the repository requires manual merge.
 
 ## Pull request finalization runbook
 
@@ -67,13 +65,7 @@ Applies to all repositories governed by these standards.
    branches, and prune remotes. If the command is not available, perform steps
    5-6 manually.
 5. Delete the local feature branch and prune remotes.
-6. Run final validation unless the docs-only exception applies.
-
-## Docs-only exception runbook
-
-1. Determine whether the diff qualifies as docs-only per repository standards.
-2. If docs-only, run markdownlint and skip other test or validation suites.
-3. If not docs-only, run the full required validation set.
+6. Run final validation.
 
 ## Maintenance
 

--- a/docs/site/docs/development/go/overview.md
+++ b/docs/site/docs/development/go/overview.md
@@ -51,9 +51,6 @@ Branch applicability:
 - release: all hard gates required
 - main: all hard gates required
 
-Docs-only pull requests may skip these jobs when the repository implements the
-docs-only CI skip policy.
-
 ## Document Map
 
 - Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/docs/site/docs/development/java/overview.md
+++ b/docs/site/docs/development/java/overview.md
@@ -53,9 +53,6 @@ Branch applicability:
 - release: all hard gates required
 - main: all hard gates required
 
-Docs-only pull requests may skip these jobs when the repository implements the
-docs-only CI skip policy.
-
 ## Document Map
 
 - Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/docs/site/docs/development/python/overview.md
+++ b/docs/site/docs/development/python/overview.md
@@ -50,9 +50,6 @@ Branch applicability:
 - release: all hard gates required
 - main: all hard gates required
 
-Docs-only pull requests may skip these jobs when the repository implements the
-docs-only CI skip policy.
-
 When dual-minor testing is active, label jobs by role:
 
 - `test-and-validate (current)` is required.

--- a/docs/site/docs/development/shell/overview.md
+++ b/docs/site/docs/development/shell/overview.md
@@ -54,9 +54,6 @@ Branch applicability:
 - release: all hard gates required
 - main: all hard gates required
 
-Docs-only pull requests may skip these jobs when the repository implements the
-docs-only CI skip policy.
-
 ## Document Map
 
 - Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -25,8 +25,7 @@ Skill bodies must remain aligned with the canonical documents they reference.
   operations summaries (autocomplete-friendly).
 - `summarize-soc` (`skills/summarize-soc/SKILL.md`): wrapper for SOC capture
   summaries (autocomplete-friendly).
-- `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow with
-  docs-only exception handling.
+- `pr-workflow` (`skills/pr-workflow/SKILL.md`): pull request workflow.
 - `dependency-update` (`skills/dependency-update/SKILL.md`): dependency update
   workflow with failure handling and anchor rules.
 - `deprecation-triage` (`skills/deprecation-triage/SKILL.md`): deprecation

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-workflow
-description: Guide pull request creation, submission, and finalization using the canonical PR workflow, including the docs-only exception.
+description: Guide pull request creation, submission, and finalization using the canonical PR workflow.
 ---
 
 # PR workflow
@@ -9,7 +9,6 @@ description: Guide pull request creation, submission, and finalization using the
 
 - [Overview](#overview)
 - [Preflight](#preflight)
-- [Docs-only determination](#docs-only-determination)
 - [Pre-submission steps](#pre-submission-steps)
 - [Submission](#submission)
 - [Finalization](#finalization)
@@ -30,14 +29,6 @@ always enabled; CI gates are the sole merge authority.
 - Locate the pull request template at `.github/pull_request_template.md`.
 - Ensure commit message format and AI co-authorship requirements are met per
   the commit standards and the repo's approved AI identity list.
-
-## Docs-only determination
-
-- Identify whether the change set is "docs-only" as defined by the repository.
-- If the repository does not define a docs-only rule, ask for it before
-  applying the exception.
-- When using the docs-only exception, include `Docs-only: tests skipped` in the
-  PR description and list the files changed.
 
 ## Pre-submission steps
 
@@ -70,7 +61,7 @@ the steps manually:
 2. Delete the local feature branch.
 3. Prune stale remote-tracking references.
 
-Then run final validation (skip for docs-only PRs).
+Then run final validation.
 
 Finalization is mandatory. Do not stop after submission or ask for permission
 to finalize.


### PR DESCRIPTION
# Pull Request

## Summary

- Remove docs-only CI skip policy, Docs-Only Exception, and all docs-only references from standards and skills

## Issue Linkage

- Ref wphillipmoore/standard-actions#108

## Testing



## Notes

- -