### PR TITLE
refactor: remove lingering docs-only references from CI workflow, submit-pr script, and shared-actions docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-only:
-    name: "ci: docs-only"
-    runs-on: ubuntu-latest
-    outputs:
-      docs-only: ${{ steps.detect.outputs.docs-only }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Detect docs-only changes
-        id: detect
-        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
-
   standards-compliance:
     name: "ci: standards-compliance"
     runs-on: ubuntu-latest

--- a/docs/site/docs/code-management/shared-actions-library.md
+++ b/docs/site/docs/code-management/shared-actions-library.md
@@ -73,8 +73,8 @@ The documentation site includes:
 
 - **Action reference** — Detailed inputs, outputs, permissions, and usage
   examples for all composite actions.
-- **CI gate requirements** — Target-state specification for required checks,
-  docs-only optimization, and security scanning.
+- **CI gate requirements** — Target-state specification for required checks
+  and security scanning.
 - **Development guides** — Environment setup, validation, and contributing
   guidelines.
 

--- a/scripts/dev/submit-pr.sh
+++ b/scripts/dev/submit-pr.sh
@@ -14,7 +14,6 @@ linkage="Fixes"
 summary=""
 notes=""
 title=""
-docs_only=false
 dry_run=false
 
 # --- Argument parsing ---
@@ -32,7 +31,6 @@ Optional:
                     Allowed: Fixes, Closes, Resolves, Ref
   --notes TEXT      Additional notes for the PR
   --title TEXT      PR title (default: most recent commit subject)
-  --docs-only       Apply docs-only exception to testing section
   --dry-run         Print the PR body and command without executing
   -h, --help        Show this help
 EOF
@@ -46,7 +44,6 @@ while [[ $# -gt 0 ]]; do
     --summary)  summary="$2"; shift 2 ;;
     --notes)    notes="$2";   shift 2 ;;
     --title)    title="$2";   shift 2 ;;
-    --docs-only) docs_only=true; shift ;;
     --dry-run)  dry_run=true; shift ;;
     -h|--help)  usage ;;
     *)
@@ -128,20 +125,6 @@ if [[ -f "$template_file" ]]; then
   while [[ "$testing_section" == *$'\n' ]]; do
     testing_section="${testing_section%$'\n'}"
   done
-fi
-
-if [[ "$docs_only" == true ]]; then
-  changed_files="$(git diff --name-only "${target_branch}...HEAD" 2>/dev/null || git diff --name-only HEAD~1)"
-  prefixed_files=""
-  while IFS= read -r file; do
-    prefixed_files="${prefixed_files}- ${file}
-"
-  done <<< "$changed_files"
-  testing_section="Docs-only: tests skipped
-
-Changed files:
-${prefixed_files%
-}"
 fi
 
 # --- Build notes section ---


### PR DESCRIPTION
# Pull Request

## Summary

- Remove lingering docs-only references from CI workflow, submit-pr script, and shared-actions documentation

## Issue Linkage

- Ref wphillipmoore/standard-actions#108

## Testing



## Notes

- -