### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
# Pull Request

## Summary

- Switch docs workflow to run inside ghcr.io/wphillipmoore/dev-docs:latest container.

## Issue Linkage

- Fixes #351

## Testing



## Notes

- -