### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.3
         with:
           skip-sync-check: "true"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: cat VERSION | cut -d. -f1,2


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #355

## Testing



## Notes

- Pins all standard-actions refs to @v1.3 rolling minor tag. Tracking: standard-actions#145.