### PR TITLE
chore(ci): upgrade standard-actions from @v1.3 to @v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.3
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.4
         with:
           skip-sync-check: "true"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
         with:
           version-command: cat VERSION | cut -d. -f1,2


### PR DESCRIPTION
## Summary

- Upgrade all standard-actions workflow references from `@v1.3` to `@v1.4`

## What changed in v1.4

- Trivy table-to-stdout output for CI visibility
- Trivy bump to 0.70.0
- CI action pin updates (create-github-app-token v3, attest-build-provenance v4)
- Workflow cleanups

Ref wphillipmoore/standard-actions#245
