### PR TITLE
docs: fleet docs sweep

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# pre-commit gate — admits st-commit-driven commits and legitimate
+# derived-commit workflows; rejects raw `git commit`.
+
+# Admit st-commit-driven commits.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then
+	echo "pre-commit gate: admitted (ST_COMMIT_CONTEXT=1)" >&2
+	exit 0
+fi
+
+# Admit derived-commit workflows that legitimately invoke `git commit`
+# without going through st-commit (amend, rebase, cherry-pick, revert,
+# merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
+case "${GIT_REFLOG_ACTION:-}" in
+amend | cherry-pick | revert | rebase* | merge*)
+	echo "pre-commit gate: admitted (GIT_REFLOG_ACTION=${GIT_REFLOG_ACTION})" >&2
+	exit 0
+	;;
+esac
+
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,5 @@
 # Standards and Conventions - Agent Instructions
 
-<!-- include: docs/site/docs/standards-and-conventions.md -->
-<!-- include: ./docs/repository-standards.md -->
-
 ## User Overrides (Optional)
 
 Always apply this repository's `AGENTS.md` as the baseline. If

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working in this repository.
 
-<!-- include: docs/site/docs/standards-and-conventions.md -->
-<!-- include: docs/repository-standards.md -->
-
-<!-- include: skills/project-issue/SKILL.md -->
-<!-- include: skills/branch-workflow/SKILL.md -->
-
 ## Auto-memory policy
 
 **Do NOT use MEMORY.md.** Never write to MEMORY.md or any file under the
@@ -94,7 +88,7 @@ This is the **canonical standards and conventions repository**. All other reposi
 ## Environment Setup
 
 ```bash
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks  # Enable git hooks
+git config core.hooksPath .githooks  # Enable git hooks
 ```
 
 Standard-tooling CLI tools (`st-commit`, `st-validate-local`, etc.) are
@@ -116,12 +110,12 @@ and are available on PATH automatically.
 
 ## Repository Standards Quick Reference
 
-The include directives above load the full repository standards. Key highlights for quick reference:
+Key highlights for quick reference:
 
 **Pre-flight Checklist**:
 - Check current branch: `git status -sb`
 - If on `develop`, create `feature/*` branch before making changes
-- Enable git hooks: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`
+- Enable git hooks: `git config core.hooksPath .githooks`
 - Verify `st-*` tools are on PATH: `command -v st-commit`
 
 **Repository Profile**:


### PR DESCRIPTION
# Pull Request

## Summary

- Sub-issue of standard-tooling#288. Creates .githooks/pre-commit env-var gate, removes 6 include directives, and replaces 2 stale core.hooksPath references from ../standard-tooling/scripts/lib/git-hooks to .githooks.

## Issue Linkage

- Fixes #358

## Testing



## Notes

- -