### PR TITLE
chore: strip config sections from repository-standards.md

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -2,31 +2,9 @@
 
 ## Table of Contents
 
-- [AI co-authors](#ai-co-authors)
-- [Repository profile](#repository-profile)
-- [Validation policy](#validation-policy)
 - [External tooling dependencies](#external-tooling-dependencies)
 - [CI gates](#ci-gates)
 - [Local deviations](#local-deviations)
-
-## AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-
-## Repository profile
-
-- repository_type: documentation
-- versioning_scheme: library
-- branching_model: library-release
-- release_model: artifact-publishing
-- supported_release_lines: 1.1
-- primary_language: none
-
-## Validation policy
-
-- canonical_local_validation_command: markdown-standards
-- validation_required: yes (markdownlint required)
 
 ## External tooling dependencies
 


### PR DESCRIPTION
# Pull Request

## Summary

- Strip AI co-authors, Repository profile, and Validation policy sections from repository-standards.md — values now in standard-tooling.toml

## Issue Linkage

- Ref #363

## Testing



## Notes

- -