### PR TITLE
chore(ci): replace retired dev-docs image with dev-base in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
# Pull Request

## Summary

- Replace retired dev-docs container image with dev-base in docs workflow. Part of wphillipmoore/standard-tooling#430.

## Issue Linkage

- Ref #367

## Testing



## Notes

- -