### PR TITLE
chore: add [ci] section to standard-tooling.toml

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,6 +9,10 @@ primary-language = "none"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["latest"]
+integration-tests = false
+
 [publish]
 docs = true
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add missing [ci] section to standard-tooling.toml so st-github-config audit/apply no longer crashes due to missing required section

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#376

## Testing



## Notes

- -